### PR TITLE
IRM-5283 Buttons

### DIFF
--- a/src/components/common/buttonV2/RcSesButtonV2.test.ts
+++ b/src/components/common/buttonV2/RcSesButtonV2.test.ts
@@ -1,0 +1,190 @@
+/* eslint-disable vue/one-component-per-file */
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+
+import RcSesButtonV2 from './RcSesButtonV2.vue'
+import type { ButtonProps } from './types'
+
+const VBtnStub = defineComponent({
+  name: 'VBtn',
+  inheritAttrs: false,
+  props: {
+    loading: { type: Boolean, default: false },
+    prependIcon: { type: String, default: undefined },
+    appendIcon: { type: String, default: undefined },
+    icon: { type: [String, Boolean], default: undefined },
+    variant: { type: String, default: undefined },
+    size: { type: String, default: undefined },
+    disabled: { type: Boolean, default: false },
+  },
+  setup(props, { slots, attrs }) {
+    return () =>
+      h(
+        'button',
+        {
+          type: 'button',
+          ...attrs,
+          'data-loading': props.loading ? 'true' : 'false',
+          'data-prepend-icon': props.prependIcon,
+          'data-append-icon': props.appendIcon,
+          'data-icon': props.icon,
+          'data-variant': props.variant,
+          'data-size': props.size,
+          disabled: props.disabled,
+        },
+        [slots.prepend?.(), slots.default?.(), slots.append?.(), slots.loader?.()],
+      )
+  },
+})
+
+const VIconStub = defineComponent({
+  name: 'VIcon',
+  setup(_, { slots }) {
+    return () => h('span', { class: 'v-icon' }, slots.default?.())
+  },
+})
+
+describe('RcSesButtonV2', () => {
+  it('renders slot content', () => {
+    render(RcSesButtonV2, {
+      slots: { default: 'Click me' },
+      global: {
+        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
+      },
+    })
+
+    expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument()
+  })
+
+  it('maps primary variant to flat v-btn variant', () => {
+    render(RcSesButtonV2, {
+      props: { variant: 'primary' },
+      slots: { default: 'Button' },
+      global: {
+        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
+      },
+    })
+
+    expect(screen.getByRole('button')).toHaveAttribute('data-variant', 'flat')
+  })
+
+  it('maps secondary variant to outlined v-btn variant', () => {
+    render(RcSesButtonV2, {
+      props: { variant: 'secondary' },
+      slots: { default: 'Button' },
+      global: {
+        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
+      },
+    })
+
+    expect(screen.getByRole('button')).toHaveAttribute('data-variant', 'outlined')
+  })
+
+  it('uses v-btn loading for text-only loading state', () => {
+    render(RcSesButtonV2, {
+      props: { loading: true },
+      slots: { default: 'Button' },
+      global: {
+        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
+      },
+    })
+
+    const button = screen.getByRole('button')
+    expect(button).toHaveAttribute('data-loading', 'true')
+    expect(button.className).toContain('rc-ses-btn-v2--text-loading')
+  })
+
+  it('replaces prepend icon with spinner when loading', () => {
+    render(RcSesButtonV2, {
+      props: { loading: true, prependIcon: '$plus' },
+      slots: { default: 'Button' },
+      global: {
+        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
+      },
+    })
+
+    const button = screen.getByRole('button')
+    expect(button).toHaveAttribute('data-loading', 'false')
+    expect(button).toHaveAttribute('data-prepend-icon', '$spinner')
+    expect(button.className).toContain('rc-ses-btn-v2--loading')
+    expect(button.className).not.toContain('rc-ses-btn-v2--text-loading')
+  })
+
+  it('treats bare loading attribute as loading state', () => {
+    render(RcSesButtonV2, {
+      props: { loading: '' as ButtonProps['loading'], prependIcon: '$plus' },
+      slots: { default: 'Button' },
+      global: {
+        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
+      },
+    })
+
+    const button = screen.getByRole('button')
+    expect(button).toHaveAttribute('data-prepend-icon', '$spinner')
+    expect(button.className).toContain('rc-ses-btn-v2--loading')
+  })
+
+  it('renders icon-only button with icon prop', () => {
+    render(RcSesButtonV2, {
+      props: { icon: '$plus', accessibleLabel: 'Add item' },
+      global: {
+        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
+      },
+    })
+
+    const button = screen.getByRole('button', { name: 'Add item' })
+    expect(button).toHaveAttribute('data-icon', 'true')
+    expect(button).toHaveAttribute('aria-label', 'Add item')
+    expect(button.className).toContain('rc-ses-btn-v2--icon-only')
+    expect(button.querySelector('.v-icon')).toBeInTheDocument()
+  })
+
+  it('sets aria-busy when loading with custom spinner', () => {
+    render(RcSesButtonV2, {
+      props: { loading: true, prependIcon: '$plus' },
+      slots: { default: 'Button' },
+      global: {
+        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
+      },
+    })
+
+    expect(screen.getByRole('button')).toHaveAttribute('aria-busy', 'true')
+  })
+
+  it('renders spinner for icon-only loading state', () => {
+    render(RcSesButtonV2, {
+      props: { icon: '$plus', loading: true, accessibleLabel: 'Add item' },
+      slots: { default: 'Button' },
+      global: {
+        stubs: {
+          VBtn: VBtnStub,
+          VIcon: defineComponent({
+            name: 'VIcon',
+            props: { icon: { type: String, default: undefined } },
+            setup(iconProps) {
+              return () => h('span', { class: 'v-icon', 'data-icon': iconProps.icon })
+            },
+          }),
+        },
+      },
+    })
+
+    const button = screen.getByRole('button', { name: 'Add item' })
+    expect(button).toHaveAttribute('data-loading', 'false')
+    expect(button).toHaveAttribute('aria-busy', 'true')
+    expect(button.querySelector('.v-icon')).toHaveAttribute('data-icon', '$spinner')
+    expect(button.className).toContain('rc-ses-btn-v2--loading')
+  })
+
+  it('does not apply loading class when loading is undefined', () => {
+    render(RcSesButtonV2, {
+      slots: { default: 'Button' },
+      global: {
+        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
+      },
+    })
+
+    expect(screen.getByRole('button').className).not.toContain('rc-ses-btn-v2--loading')
+  })
+})

--- a/src/components/common/buttonV2/RcSesButtonV2.test.ts
+++ b/src/components/common/buttonV2/RcSesButtonV2.test.ts
@@ -45,146 +45,115 @@ const VIconStub = defineComponent({
   },
 })
 
+const VIconWithDataIconStub = defineComponent({
+  name: 'VIcon',
+  props: { icon: { type: String, default: undefined } },
+  setup(iconProps) {
+    return () => h('span', { class: 'v-icon', 'data-icon': iconProps.icon })
+  },
+})
+
+const renderButton = (
+  props: Partial<ButtonProps> = {},
+  slots: Record<string, string> = {},
+  iconStub = VIconStub,
+) =>
+  render(RcSesButtonV2, {
+    props,
+    slots,
+    global: {
+      stubs: { VBtn: VBtnStub, VIcon: iconStub },
+    },
+  })
+
 describe('RcSesButtonV2', () => {
-  it('renders slot content', () => {
-    render(RcSesButtonV2, {
-      slots: { default: 'Click me' },
-      global: {
-        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
-      },
+  describe('render basics', () => {
+    it('renders slot content', () => {
+      renderButton({}, { default: 'Click me' })
+
+      expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument()
     })
 
-    expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument()
+    describe('variant mapping', () => {
+      it.each([
+        ['primary', 'flat'],
+        ['secondary', 'outlined'],
+        ['error', 'flat'],
+        ['link', 'text'],
+      ] as const)('maps %s to %s v-btn variant', (variant, expected) => {
+        renderButton({ variant }, { default: 'Button' })
+
+        expect(screen.getByRole('button')).toHaveAttribute('data-variant', expected)
+      })
+    })
   })
 
-  it('maps primary variant to flat v-btn variant', () => {
-    render(RcSesButtonV2, {
-      props: { variant: 'primary' },
-      slots: { default: 'Button' },
-      global: {
-        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
-      },
+  describe('loading states', () => {
+    it('uses v-btn loading for text-only loading state', () => {
+      renderButton({ loading: true }, { default: 'Button' })
+
+      const button = screen.getByRole('button')
+      expect(button).toHaveAttribute('data-loading', 'true')
+      expect(button.className).toContain('rc-ses-btn-v2--text-loading')
     })
 
-    expect(screen.getByRole('button')).toHaveAttribute('data-variant', 'flat')
+    it('replaces prepend icon with spinner when loading', () => {
+      renderButton({ loading: true, prependIcon: '$plus' }, { default: 'Button' })
+
+      const button = screen.getByRole('button')
+      expect(button).toHaveAttribute('data-loading', 'false')
+      expect(button).toHaveAttribute('data-prepend-icon', '$spinner')
+      expect(button.className).toContain('rc-ses-btn-v2--loading')
+      expect(button.className).not.toContain('rc-ses-btn-v2--text-loading')
+    })
+
+    it('treats bare loading attribute as loading state', () => {
+      renderButton(
+        { loading: '' as ButtonProps['loading'], prependIcon: '$plus' },
+        { default: 'Button' },
+      )
+
+      const button = screen.getByRole('button')
+      expect(button).toHaveAttribute('data-prepend-icon', '$spinner')
+      expect(button.className).toContain('rc-ses-btn-v2--loading')
+    })
+
+    it('sets aria-busy when loading with custom spinner', () => {
+      renderButton({ loading: true, prependIcon: '$plus' }, { default: 'Button' })
+
+      expect(screen.getByRole('button')).toHaveAttribute('aria-busy', 'true')
+    })
+
+    it('does not apply loading class when loading is undefined', () => {
+      renderButton({}, { default: 'Button' })
+
+      expect(screen.getByRole('button').className).not.toContain('rc-ses-btn-v2--loading')
+    })
   })
 
-  it('maps secondary variant to outlined v-btn variant', () => {
-    render(RcSesButtonV2, {
-      props: { variant: 'secondary' },
-      slots: { default: 'Button' },
-      global: {
-        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
-      },
+  describe('icon-only mode', () => {
+    it('renders icon-only button with icon prop', () => {
+      renderButton({ icon: '$plus', accessibleLabel: 'Add item' })
+
+      const button = screen.getByRole('button', { name: 'Add item' })
+      expect(button).toHaveAttribute('data-icon', 'true')
+      expect(button).toHaveAttribute('aria-label', 'Add item')
+      expect(button.className).toContain('rc-ses-btn-v2--icon-only')
+      expect(button.querySelector('.v-icon')).toBeInTheDocument()
     })
 
-    expect(screen.getByRole('button')).toHaveAttribute('data-variant', 'outlined')
-  })
+    it('renders spinner for icon-only loading state', () => {
+      renderButton(
+        { icon: '$plus', loading: true, accessibleLabel: 'Add item' },
+        { default: 'Button' },
+        VIconWithDataIconStub,
+      )
 
-  it('uses v-btn loading for text-only loading state', () => {
-    render(RcSesButtonV2, {
-      props: { loading: true },
-      slots: { default: 'Button' },
-      global: {
-        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
-      },
+      const button = screen.getByRole('button', { name: 'Add item' })
+      expect(button).toHaveAttribute('data-loading', 'false')
+      expect(button).toHaveAttribute('aria-busy', 'true')
+      expect(button.querySelector('.v-icon')).toHaveAttribute('data-icon', '$spinner')
+      expect(button.className).toContain('rc-ses-btn-v2--loading')
     })
-
-    const button = screen.getByRole('button')
-    expect(button).toHaveAttribute('data-loading', 'true')
-    expect(button.className).toContain('rc-ses-btn-v2--text-loading')
-  })
-
-  it('replaces prepend icon with spinner when loading', () => {
-    render(RcSesButtonV2, {
-      props: { loading: true, prependIcon: '$plus' },
-      slots: { default: 'Button' },
-      global: {
-        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
-      },
-    })
-
-    const button = screen.getByRole('button')
-    expect(button).toHaveAttribute('data-loading', 'false')
-    expect(button).toHaveAttribute('data-prepend-icon', '$spinner')
-    expect(button.className).toContain('rc-ses-btn-v2--loading')
-    expect(button.className).not.toContain('rc-ses-btn-v2--text-loading')
-  })
-
-  it('treats bare loading attribute as loading state', () => {
-    render(RcSesButtonV2, {
-      props: { loading: '' as ButtonProps['loading'], prependIcon: '$plus' },
-      slots: { default: 'Button' },
-      global: {
-        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
-      },
-    })
-
-    const button = screen.getByRole('button')
-    expect(button).toHaveAttribute('data-prepend-icon', '$spinner')
-    expect(button.className).toContain('rc-ses-btn-v2--loading')
-  })
-
-  it('renders icon-only button with icon prop', () => {
-    render(RcSesButtonV2, {
-      props: { icon: '$plus', accessibleLabel: 'Add item' },
-      global: {
-        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
-      },
-    })
-
-    const button = screen.getByRole('button', { name: 'Add item' })
-    expect(button).toHaveAttribute('data-icon', 'true')
-    expect(button).toHaveAttribute('aria-label', 'Add item')
-    expect(button.className).toContain('rc-ses-btn-v2--icon-only')
-    expect(button.querySelector('.v-icon')).toBeInTheDocument()
-  })
-
-  it('sets aria-busy when loading with custom spinner', () => {
-    render(RcSesButtonV2, {
-      props: { loading: true, prependIcon: '$plus' },
-      slots: { default: 'Button' },
-      global: {
-        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
-      },
-    })
-
-    expect(screen.getByRole('button')).toHaveAttribute('aria-busy', 'true')
-  })
-
-  it('renders spinner for icon-only loading state', () => {
-    render(RcSesButtonV2, {
-      props: { icon: '$plus', loading: true, accessibleLabel: 'Add item' },
-      slots: { default: 'Button' },
-      global: {
-        stubs: {
-          VBtn: VBtnStub,
-          VIcon: defineComponent({
-            name: 'VIcon',
-            props: { icon: { type: String, default: undefined } },
-            setup(iconProps) {
-              return () => h('span', { class: 'v-icon', 'data-icon': iconProps.icon })
-            },
-          }),
-        },
-      },
-    })
-
-    const button = screen.getByRole('button', { name: 'Add item' })
-    expect(button).toHaveAttribute('data-loading', 'false')
-    expect(button).toHaveAttribute('aria-busy', 'true')
-    expect(button.querySelector('.v-icon')).toHaveAttribute('data-icon', '$spinner')
-    expect(button.className).toContain('rc-ses-btn-v2--loading')
-  })
-
-  it('does not apply loading class when loading is undefined', () => {
-    render(RcSesButtonV2, {
-      slots: { default: 'Button' },
-      global: {
-        stubs: { VBtn: VBtnStub, VIcon: VIconStub },
-      },
-    })
-
-    expect(screen.getByRole('button').className).not.toContain('rc-ses-btn-v2--loading')
   })
 })

--- a/src/components/common/buttonV2/RcSesButtonV2.vue
+++ b/src/components/common/buttonV2/RcSesButtonV2.vue
@@ -3,16 +3,16 @@
     :class="buttonClasses"
     v-bind="vuetifyProps"
     :aria-label="props.accessibleLabel"
-    :aria-busy="isLoading || undefined"
+    :aria-busy="iconState.loading || undefined"
   >
-    <v-icon v-if="isIconOnly" :icon="iconButtonIcon" aria-hidden="true" />
+    <v-icon v-if="iconState.iconOnly" :icon="iconState.buttonIcon" aria-hidden="true" />
     <slot v-else />
 
-    <template v-if="!isIconOnly && $slots.append" #append>
+    <template v-if="!iconState.iconOnly && $slots.append" #append>
       <slot name="append" />
     </template>
 
-    <template v-if="!isIconOnly && $slots.prepend" #prepend>
+    <template v-if="!iconState.iconOnly && $slots.prepend" #prepend>
       <slot name="prepend" />
     </template>
 
@@ -22,25 +22,54 @@
   </v-btn>
 </template>
 
+<script lang="ts">
+/* eslint-disable import/no-duplicates -- dual script block for exported prop types */
+import type { DefineComponent } from 'vue'
+
+import type { ButtonProps } from '@/components/common/buttonV2/types'
+
+export default {} as DefineComponent<ButtonProps>
+</script>
+
 <script setup lang="ts">
-import { computed, withDefaults } from 'vue'
+/* eslint-disable import/first, import/no-duplicates -- dual script block for exported prop types */
+import { computed, useAttrs, withDefaults } from 'vue'
 
 import ButtonDefaults from '@/components/common/buttonV2/defaults'
-import type { ButtonProps } from '@/components/common/buttonV2/types'
+import type { ButtonOwnProps } from '@/components/common/buttonV2/types'
 
 import './style.scss'
 
-const props = withDefaults(defineProps<ButtonProps>(), ButtonDefaults)
+defineOptions({ inheritAttrs: false })
 
-const isLoading = computed(() => props.loading != null && props.loading !== false)
-const isIconOnly = computed(() => !!props.icon && props.icon !== true)
-const hasIconSlot = computed(
-  () => isIconOnly.value || !!(props.prependIcon || props.appendIcon),
-)
+const variantMap = {
+  primary: 'flat',
+  secondary: 'outlined',
+  error: 'flat',
+  link: 'text',
+} as const
 
-const iconButtonIcon = computed(() => {
-  if (!isIconOnly.value || !props.icon || props.icon === true) return undefined
-  return isLoading.value ? '$spinner' : props.icon
+const props = withDefaults(defineProps<ButtonOwnProps>(), ButtonDefaults)
+const attrs = useAttrs()
+
+const iconState = computed(() => {
+  const loading = props.loading != null && props.loading !== false
+  const iconOnly = !!props.icon && props.icon !== true
+  const useCustomSpinner =
+    loading && (iconOnly || !!props.prependIcon || !!props.appendIcon)
+
+  const withSpinner = (icon?: ButtonOwnProps['prependIcon']) =>
+    loading && icon ? '$spinner' : icon
+
+  return {
+    loading,
+    iconOnly,
+    useCustomSpinner,
+    buttonIcon:
+      iconOnly && typeof props.icon === 'string' ? withSpinner(props.icon) : undefined,
+    prependIcon: withSpinner(props.prependIcon),
+    appendIcon: withSpinner(props.appendIcon),
+  }
 })
 
 const buttonClasses = computed(() => [
@@ -48,43 +77,28 @@ const buttonClasses = computed(() => [
   `rc-ses-btn-v2--${props.variant}`,
   `rc-ses-btn-v2--${props.size}`,
   {
-    'rc-ses-btn-v2--loading': isLoading.value,
-    'rc-ses-btn-v2--icon-only': isIconOnly.value,
-    'rc-ses-btn-v2--text-loading': isLoading.value && !hasIconSlot.value,
+    'rc-ses-btn-v2--loading': iconState.value.loading,
+    'rc-ses-btn-v2--icon-only': iconState.value.iconOnly,
+    'rc-ses-btn-v2--text-loading':
+      iconState.value.loading && !iconState.value.useCustomSpinner,
   },
 ])
 
 const vuetifyProps = computed(() => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const {
-    variant: buttonVariant,
-    size: buttonSize,
-    color,
-    icon,
-    accessibleLabel,
-    ...vBtnProps
-  } = props
-
-  const loading = isLoading.value
-  const useCustomSpinner = loading && hasIconSlot.value
-
-  let variantValue: 'flat' | 'outlined' | 'text' = 'flat'
-  if (buttonVariant === 'secondary') variantValue = 'outlined'
-  if (buttonVariant === 'link') variantValue = 'text'
-
-  const resolveIcon = (iconValue: ButtonProps['prependIcon']) => {
-    if (!iconValue) return undefined
-    return loading ? '$spinner' : iconValue
-  }
+  const { color, ...passthroughAttrs } = attrs
 
   return {
-    ...vBtnProps,
-    variant: variantValue,
-    size: buttonSize === 'small' ? 'small' : 'default',
-    loading: loading && !useCustomSpinner,
-    prependIcon: resolveIcon(props.prependIcon),
-    appendIcon: resolveIcon(props.appendIcon),
-    icon: isIconOnly.value ? true : undefined,
+    ...passthroughAttrs,
+    disabled: props.disabled,
+    density: props.density,
+    flat: props.flat,
+    variant: variantMap[(props.variant ?? 'primary') as keyof typeof variantMap],
+    size: props.size === 'small' ? 'small' : 'default',
+    loading: iconState.value.loading && !iconState.value.useCustomSpinner,
+    prependIcon: iconState.value.prependIcon,
+    appendIcon: iconState.value.appendIcon,
+    icon: iconState.value.iconOnly ? true : undefined,
   }
 })
 </script>

--- a/src/components/common/buttonV2/RcSesButtonV2.vue
+++ b/src/components/common/buttonV2/RcSesButtonV2.vue
@@ -1,0 +1,90 @@
+<template>
+  <v-btn
+    :class="buttonClasses"
+    v-bind="vuetifyProps"
+    :aria-label="props.accessibleLabel"
+    :aria-busy="isLoading || undefined"
+  >
+    <v-icon v-if="isIconOnly" :icon="iconButtonIcon" aria-hidden="true" />
+    <slot v-else />
+
+    <template v-if="!isIconOnly && $slots.append" #append>
+      <slot name="append" />
+    </template>
+
+    <template v-if="!isIconOnly && $slots.prepend" #prepend>
+      <slot name="prepend" />
+    </template>
+
+    <template v-if="$slots.loader" #loader>
+      <slot name="loader" />
+    </template>
+  </v-btn>
+</template>
+
+<script setup lang="ts">
+import { computed, withDefaults } from 'vue'
+
+import ButtonDefaults from '@/components/common/buttonV2/defaults'
+import type { ButtonProps } from '@/components/common/buttonV2/types'
+
+import './style.scss'
+
+const props = withDefaults(defineProps<ButtonProps>(), ButtonDefaults)
+
+const isLoading = computed(() => props.loading != null && props.loading !== false)
+const isIconOnly = computed(() => !!props.icon && props.icon !== true)
+const hasIconSlot = computed(
+  () => isIconOnly.value || !!(props.prependIcon || props.appendIcon),
+)
+
+const iconButtonIcon = computed(() => {
+  if (!isIconOnly.value || !props.icon || props.icon === true) return undefined
+  return isLoading.value ? '$spinner' : props.icon
+})
+
+const buttonClasses = computed(() => [
+  'rc-ses-btn-v2',
+  `rc-ses-btn-v2--${props.variant}`,
+  `rc-ses-btn-v2--${props.size}`,
+  {
+    'rc-ses-btn-v2--loading': isLoading.value,
+    'rc-ses-btn-v2--icon-only': isIconOnly.value,
+    'rc-ses-btn-v2--text-loading': isLoading.value && !hasIconSlot.value,
+  },
+])
+
+const vuetifyProps = computed(() => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const {
+    variant: buttonVariant,
+    size: buttonSize,
+    color,
+    icon,
+    accessibleLabel,
+    ...vBtnProps
+  } = props
+
+  const loading = isLoading.value
+  const useCustomSpinner = loading && hasIconSlot.value
+
+  let variantValue: 'flat' | 'outlined' | 'text' = 'flat'
+  if (buttonVariant === 'secondary') variantValue = 'outlined'
+  if (buttonVariant === 'link') variantValue = 'text'
+
+  const resolveIcon = (iconValue: ButtonProps['prependIcon']) => {
+    if (!iconValue) return undefined
+    return loading ? '$spinner' : iconValue
+  }
+
+  return {
+    ...vBtnProps,
+    variant: variantValue,
+    size: buttonSize === 'small' ? 'small' : 'default',
+    loading: loading && !useCustomSpinner,
+    prependIcon: resolveIcon(props.prependIcon),
+    appendIcon: resolveIcon(props.appendIcon),
+    icon: isIconOnly.value ? true : undefined,
+  }
+})
+</script>

--- a/src/components/common/buttonV2/defaults.ts
+++ b/src/components/common/buttonV2/defaults.ts
@@ -1,42 +1,21 @@
 import type { VBtn } from 'vuetify/components'
 
-import { ButtonSize, ButtonVariants } from '@/components/common/buttonV2/types'
-import type { ColorType } from '@/types/common/ColorType'
+import type { ButtonSize, ButtonVariants } from '@/components/common/buttonV2/types'
 
-export default {
-  accessibleLabel: undefined,
-  appendIcon: undefined,
-  baseColor: undefined,
-  block: undefined,
-  border: undefined,
-  color: 'primary' as ColorType,
-  density: 'default' as VBtn['$props']['density'],
-  disabled: false,
-  elevation: undefined,
-  exact: undefined,
-  flat: false,
-  height: undefined,
-  href: undefined,
-  icon: undefined,
-  loading: undefined,
-  maxHeight: undefined,
-  maxWidth: undefined,
-  minHeight: undefined,
-  minWidth: undefined,
-  position: undefined,
-  prependIcon: undefined,
-  readonly: undefined,
-  replace: undefined,
-  selectedClass: undefined,
-  size: 'regular' as ButtonSize,
-  stacked: undefined,
-  symbol: undefined,
-  tag: undefined,
-  text: undefined,
-  theme: undefined,
-  tile: undefined,
-  to: undefined,
-  value: undefined,
-  variant: 'primary' as ButtonVariants,
-  width: undefined,
+export type ButtonDefaultsType = {
+  variant: ButtonVariants
+  size: ButtonSize
+  disabled: boolean
+  density: NonNullable<VBtn['$props']['density']>
+  flat: boolean
 }
+
+const buttonDefaults = {
+  variant: 'primary',
+  size: 'regular',
+  disabled: false,
+  density: 'default',
+  flat: false,
+} satisfies ButtonDefaultsType
+
+export default buttonDefaults

--- a/src/components/common/buttonV2/defaults.ts
+++ b/src/components/common/buttonV2/defaults.ts
@@ -1,0 +1,42 @@
+import type { VBtn } from 'vuetify/components'
+
+import { ButtonSize, ButtonVariants } from '@/components/common/buttonV2/types'
+import type { ColorType } from '@/types/common/ColorType'
+
+export default {
+  accessibleLabel: undefined,
+  appendIcon: undefined,
+  baseColor: undefined,
+  block: undefined,
+  border: undefined,
+  color: 'primary' as ColorType,
+  density: 'default' as VBtn['$props']['density'],
+  disabled: false,
+  elevation: undefined,
+  exact: undefined,
+  flat: false,
+  height: undefined,
+  href: undefined,
+  icon: undefined,
+  loading: undefined,
+  maxHeight: undefined,
+  maxWidth: undefined,
+  minHeight: undefined,
+  minWidth: undefined,
+  position: undefined,
+  prependIcon: undefined,
+  readonly: undefined,
+  replace: undefined,
+  selectedClass: undefined,
+  size: 'regular' as ButtonSize,
+  stacked: undefined,
+  symbol: undefined,
+  tag: undefined,
+  text: undefined,
+  theme: undefined,
+  tile: undefined,
+  to: undefined,
+  value: undefined,
+  variant: 'primary' as ButtonVariants,
+  width: undefined,
+}

--- a/src/components/common/buttonV2/style.scss
+++ b/src/components/common/buttonV2/style.scss
@@ -1,0 +1,170 @@
+@use '/src/styles/vuetify/settings.scss';
+@use '/src/styles/vuetify/typography-v2' as typo-v2;
+@use '/src/styles/vuetify/borders-v2' as borders-v2;
+@use '/src/styles/vuetify/sizes-v2' as sizes-v2;
+@use '/src/styles/vuetify/spacing-v2' as spacing-v2;
+
+.rc-ses-btn-v2 {
+  border-radius: borders-v2.rc-radius-v2('button-radius-v2');
+  @include typo-v2.rc-typography-v2('button-compact-v2');
+  padding-left: spacing-v2.rc-spacing-v2('spacing-16-v2');
+  padding-right: spacing-v2.rc-spacing-v2('spacing-16-v2');
+
+  &--loading {
+    pointer-events: none !important;
+    cursor: default !important;
+
+    .v-icon,
+    .v-btn__loader {
+      animation: rcSesSpin 1s linear infinite !important;
+    }
+  }
+
+  &--text-loading {
+    &.rc-ses-btn-v2--regular {
+      min-width: 5.5rem;
+    }
+
+    &.rc-ses-btn-v2--small {
+      min-width: 4.5rem;
+    }
+  }
+
+  .v-icon {
+    @include sizes-v2.rc-icon-size-v2('icon-medium-v2');
+  }
+
+  .v-btn__prepend {
+    margin-inline-end: spacing-v2.rc-spacing-v2('badge-icon-text-gap-v2') !important;
+    margin-inline-start: 0 !important;
+  }
+
+  .v-btn__append {
+    margin-inline-start: spacing-v2.rc-spacing-v2('badge-icon-text-gap-v2') !important;
+    margin-inline-end: 0 !important;
+  }
+
+  &:focus-visible {
+    > .v-btn__overlay {
+      opacity: 0 !important;
+    }
+  }
+
+  &:hover {
+    > .v-btn__overlay {
+      opacity: 0 !important;
+    }
+  }
+
+  &:focus-visible {
+    border-color: rgb(var(--v-theme-border-focus-actual-v2)) !important;
+  }
+
+  &:focus-visible::after {
+    border-color: rgb(var(--v-theme-border-focus-actual-v2)) !important;
+    opacity: 1 !important;
+  }
+
+  &--small {
+    height: 36px !important;
+    padding-top: spacing-v2.rc-spacing-v2('spacing-8-v2') !important;
+    padding-bottom: spacing-v2.rc-spacing-v2('spacing-8-v2') !important;
+  }
+
+  &--regular {
+    height: 44px !important;
+    padding-top: spacing-v2.rc-spacing-v2('spacing-12-v2') !important;
+    padding-bottom: spacing-v2.rc-spacing-v2('spacing-12-v2') !important;
+  }
+
+  &--icon-only {
+    width: 44px !important;
+    min-width: 44px !important;
+    max-width: 44px !important;
+    padding: 0 !important;
+
+    &.rc-ses-btn-v2--small {
+      width: 36px !important;
+      min-width: 36px !important;
+      max-width: 36px !important;
+    }
+  }
+
+  &--primary {
+    background-color: rgb(var(--v-theme-primary-bg-v2)) !important;
+    color: rgb(var(--v-theme-primary-text-v2)) !important;
+    &:hover {
+      background-color: rgb(var(--v-theme-primary-bg-hover-v2)) !important;
+    }
+
+    &:disabled {
+      background-color: rgb(var(--v-theme-primary-bg-disabled-v2)) !important;
+      color: rgb(var(--v-theme-primary-text-disabled-v2)) !important;
+      opacity: unset;
+      .v-btn__overlay {
+        background-color: unset;
+      }
+    }
+  }
+
+  &--secondary {
+    background-color: rgb(var(--v-theme-secondary-bg-v2)) !important;
+    border: 1px solid rgb(var(--v-theme-secondary-border-v2));
+    color: rgb(var(--v-theme-secondary-text-v2)) !important;
+    &:hover {
+      background-color: rgb(var(--v-theme-secondary-bg-hover-v2)) !important;
+    }
+
+    &:disabled {
+      background-color: rgb(var(--v-theme-secondary-bg-v2)) !important;
+      border-color: rgb(var(--v-theme-text-disabled-v2)) !important;
+      color: rgb(var(--v-theme-text-disabled-v2)) !important;
+      opacity: unset;
+      .v-btn__overlay {
+        background-color: unset;
+      }
+    }
+  }
+
+  &--error {
+    background-color: rgb(var(--v-theme-destructive-bg-v2)) !important;
+    color: rgb(var(--v-theme-destructive-text-v2)) !important;
+    &:hover {
+      background-color: rgb(var(--v-theme-destructive-bg-hover-v2)) !important;
+    }
+
+    &:disabled {
+      background-color: rgb(var(--v-theme-primary-bg-disabled-v2)) !important;
+      color: rgb(var(--v-theme-text-disabled-v2)) !important;
+      opacity: unset;
+      .v-btn__overlay {
+        background-color: unset;
+      }
+    }
+  }
+
+  &--link {
+    color: rgb(var(--v-theme-link-text-v2)) !important;
+    &:hover {
+      color: rgb(var(--v-theme-link-text-hover-v2)) !important;
+      background-color: unset !important;
+    }
+
+    &:disabled {
+      color: rgb(var(--v-theme-text-disabled-v2)) !important;
+      opacity: unset;
+      .v-btn__overlay {
+        background-color: unset;
+      }
+    }
+  }
+}
+
+@keyframes rcSesSpin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/common/buttonV2/style.scss
+++ b/src/components/common/buttonV2/style.scss
@@ -22,11 +22,11 @@
 
   &--text-loading {
     &.rc-ses-btn-v2--regular {
-      min-width: 5.5rem;
+      min-width: sizes-v2.rc-size-v2('button-loading-min-width-regular-v2');
     }
 
     &.rc-ses-btn-v2--small {
-      min-width: 4.5rem;
+      min-width: sizes-v2.rc-size-v2('button-loading-min-width-small-v2');
     }
   }
 
@@ -44,13 +44,7 @@
     margin-inline-end: 0 !important;
   }
 
-  &:focus-visible {
-    > .v-btn__overlay {
-      opacity: 0 !important;
-    }
-  }
-
-  &:hover {
+  &:is(:hover, :focus-visible) {
     > .v-btn__overlay {
       opacity: 0 !important;
     }
@@ -58,35 +52,35 @@
 
   &:focus-visible {
     border-color: rgb(var(--v-theme-border-focus-actual-v2)) !important;
-  }
 
-  &:focus-visible::after {
-    border-color: rgb(var(--v-theme-border-focus-actual-v2)) !important;
-    opacity: 1 !important;
+    &::after {
+      border-color: rgb(var(--v-theme-border-focus-actual-v2)) !important;
+      opacity: 1 !important;
+    }
   }
 
   &--small {
-    height: 36px !important;
+    height: sizes-v2.rc-size-v2('button-height-small-v2') !important;
     padding-top: spacing-v2.rc-spacing-v2('spacing-8-v2') !important;
     padding-bottom: spacing-v2.rc-spacing-v2('spacing-8-v2') !important;
   }
 
   &--regular {
-    height: 44px !important;
+    height: sizes-v2.rc-size-v2('button-height-regular-v2') !important;
     padding-top: spacing-v2.rc-spacing-v2('spacing-12-v2') !important;
     padding-bottom: spacing-v2.rc-spacing-v2('spacing-12-v2') !important;
   }
 
   &--icon-only {
-    width: 44px !important;
-    min-width: 44px !important;
-    max-width: 44px !important;
+    width: sizes-v2.rc-size-v2('button-height-regular-v2') !important;
+    min-width: sizes-v2.rc-size-v2('button-height-regular-v2') !important;
+    max-width: sizes-v2.rc-size-v2('button-height-regular-v2') !important;
     padding: 0 !important;
 
     &.rc-ses-btn-v2--small {
-      width: 36px !important;
-      min-width: 36px !important;
-      max-width: 36px !important;
+      width: sizes-v2.rc-size-v2('button-height-small-v2') !important;
+      min-width: sizes-v2.rc-size-v2('button-height-small-v2') !important;
+      max-width: sizes-v2.rc-size-v2('button-height-small-v2') !important;
     }
   }
 

--- a/src/components/common/buttonV2/types.ts
+++ b/src/components/common/buttonV2/types.ts
@@ -1,45 +1,39 @@
+import type { VNodeProps } from 'vue'
 import type { VBtn } from 'vuetify/components'
-
-import type { ColorType } from '@/types/common/ColorType'
 
 export type ButtonVariants = 'primary' | 'secondary' | 'error' | 'link'
 export type ButtonSize = 'small' | 'regular'
 
-export interface ButtonProps {
+type VBtnPublicProps = Omit<
+  Partial<VBtn['$props']>,
+  | keyof VNodeProps
+  | 'size'
+  | 'variant'
+  | '$children'
+  | 'v-slots'
+  | 'v-slot:default'
+  | 'v-slot:prepend'
+  | 'v-slot:append'
+  | 'v-slot:loader'
+>
+
+export type ButtonProps = VBtnPublicProps & {
+  /** Screen reader label, e.g. for icon-only buttons without visible text */
   accessibleLabel?: string
-  appendIcon?: VBtn['$props']['appendIcon']
-  baseColor?: VBtn['$props']['baseColor']
-  block?: VBtn['$props']['block']
-  border?: VBtn['$props']['border']
-  color?: ColorType
-  density?: VBtn['$props']['density']
-  disabled?: VBtn['$props']['disabled']
-  elevation?: VBtn['$props']['elevation']
-  exact?: VBtn['$props']['exact']
-  flat?: VBtn['$props']['flat']
-  height?: VBtn['$props']['height']
-  href?: VBtn['$props']['href']
-  icon?: VBtn['$props']['icon']
-  loading?: VBtn['$props']['loading']
-  location?: VBtn['$props']['location']
-  maxHeight?: VBtn['$props']['maxHeight']
-  maxWidth?: VBtn['$props']['maxWidth']
-  minHeight?: VBtn['$props']['minHeight']
-  minWidth?: VBtn['$props']['minWidth']
-  position?: VBtn['$props']['position']
-  prependIcon?: VBtn['$props']['prependIcon']
-  readonly?: VBtn['$props']['readonly']
-  replace?: VBtn['$props']['replace']
-  selectedClass?: VBtn['$props']['selectedClass']
   size?: ButtonSize
-  stacked?: VBtn['$props']['stacked']
-  symbol?: VBtn['$props']['symbol']
-  tag?: VBtn['$props']['tag']
-  text?: VBtn['$props']['text']
-  theme?: VBtn['$props']['theme']
-  tile?: VBtn['$props']['tile']
-  to?: VBtn['$props']['to']
-  value?: VBtn['$props']['value']
   variant?: ButtonVariants
-  width?: VBtn['$props']['width']
+}
+
+/** Props declared at runtime; remaining VBtn props pass through via attrs. */
+export type ButtonOwnProps = {
+  accessibleLabel?: string
+  variant?: ButtonVariants
+  size?: ButtonSize
+  loading?: VBtn['$props']['loading']
+  icon?: VBtn['$props']['icon']
+  prependIcon?: VBtn['$props']['prependIcon']
+  appendIcon?: VBtn['$props']['appendIcon']
+  disabled?: VBtn['$props']['disabled']
+  density?: VBtn['$props']['density']
+  flat?: VBtn['$props']['flat']
 }

--- a/src/components/common/buttonV2/types.ts
+++ b/src/components/common/buttonV2/types.ts
@@ -1,0 +1,45 @@
+import type { VBtn } from 'vuetify/components'
+
+import type { ColorType } from '@/types/common/ColorType'
+
+export type ButtonVariants = 'primary' | 'secondary' | 'error' | 'link'
+export type ButtonSize = 'small' | 'regular'
+
+export interface ButtonProps {
+  accessibleLabel?: string
+  appendIcon?: VBtn['$props']['appendIcon']
+  baseColor?: VBtn['$props']['baseColor']
+  block?: VBtn['$props']['block']
+  border?: VBtn['$props']['border']
+  color?: ColorType
+  density?: VBtn['$props']['density']
+  disabled?: VBtn['$props']['disabled']
+  elevation?: VBtn['$props']['elevation']
+  exact?: VBtn['$props']['exact']
+  flat?: VBtn['$props']['flat']
+  height?: VBtn['$props']['height']
+  href?: VBtn['$props']['href']
+  icon?: VBtn['$props']['icon']
+  loading?: VBtn['$props']['loading']
+  location?: VBtn['$props']['location']
+  maxHeight?: VBtn['$props']['maxHeight']
+  maxWidth?: VBtn['$props']['maxWidth']
+  minHeight?: VBtn['$props']['minHeight']
+  minWidth?: VBtn['$props']['minWidth']
+  position?: VBtn['$props']['position']
+  prependIcon?: VBtn['$props']['prependIcon']
+  readonly?: VBtn['$props']['readonly']
+  replace?: VBtn['$props']['replace']
+  selectedClass?: VBtn['$props']['selectedClass']
+  size?: ButtonSize
+  stacked?: VBtn['$props']['stacked']
+  symbol?: VBtn['$props']['symbol']
+  tag?: VBtn['$props']['tag']
+  text?: VBtn['$props']['text']
+  theme?: VBtn['$props']['theme']
+  tile?: VBtn['$props']['tile']
+  to?: VBtn['$props']['to']
+  value?: VBtn['$props']['value']
+  variant?: ButtonVariants
+  width?: VBtn['$props']['width']
+}

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -5,6 +5,7 @@ import RcSesAccordion from '@/components/common/Accordion/RcSesAccordion.vue'
 import useAccordionController from '@/components/common/Accordion/hooks/useAccordionController'
 import RcSesAlert from '@/components/common/Alert/RcSesAlert.vue'
 import RcSesError from '@/components/common/Error/RcSesError.vue'
+import RcSesButtonV2 from '@/components/common/buttonV2/RcSesButtonV2.vue'
 import RcSesButton from '@/components/common/buttons/Button/RcSesButton.vue'
 import RcSesFormControl from '@/components/common/forms/RcSesFormControl.vue'
 import RcSesCheckbox from '@/components/common/inputs/Checkboxes/Checkbox/RcSesCheckbox.vue'
@@ -70,6 +71,7 @@ export function createRcSesComponents(options: object = {}): Plugin<[]> {
 
     // eslint-disable-next-line vue/no-reserved-component-names
     app.component('RcSesButton', RcSesButton)
+    app.component('RcSesButtonV2', RcSesButtonV2)
 
     app.component('RcSesCheckbox', RcSesCheckbox)
 
@@ -128,7 +130,7 @@ export {
   RcSesFormStepper,
   RcSesFormActions,
 }
-export { RcSesAlert, RcSesButton }
+export { RcSesAlert, RcSesButton, RcSesButtonV2 }
 export { RcSesCheckbox, RcSesCheckboxField }
 export { RcSesFileInput, RcSesFileInputField }
 export { RcSesDatePicker, RcSesDatePickerField, RcSesTimePickerField }

--- a/src/stories/components v2/Button/Button.stories.ts
+++ b/src/stories/components v2/Button/Button.stories.ts
@@ -1,0 +1,119 @@
+import { StoryFn } from '@storybook/vue3'
+
+import RcSesButtonV2 from '@/components/common/buttonV2/RcSesButtonV2.vue'
+import type { ButtonProps } from '@/components/common/buttonV2/types'
+
+export default {
+  components: { RcSesButtonV2 },
+  title: 'components v2/Button',
+  component: RcSesButtonV2,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'error', 'link'],
+    },
+    size: {
+      control: 'select',
+      options: ['regular', 'small'],
+    },
+    loading: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    prependIcon: { control: 'text' },
+    appendIcon: { control: 'text' },
+    icon: { control: 'text' },
+    accessibleLabel: { control: 'text' },
+  },
+}
+
+const Template: StoryFn<ButtonProps> = (args) => ({
+  components: { RcSesButtonV2 },
+  setup() {
+    return { args }
+  },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <RcSesButtonV2 v-bind="args">Button</RcSesButtonV2>
+      </div>
+      <div class="storybook-field-previews">
+        <div class="storybook-field-previews-title">Variant previews</div>
+        <RcSesButtonV2 variant="primary">Primary</RcSesButtonV2>
+        <RcSesButtonV2 variant="secondary">Secondary</RcSesButtonV2>
+        <RcSesButtonV2 variant="error">Error</RcSesButtonV2>
+        <RcSesButtonV2 variant="link">Link</RcSesButtonV2>
+      </div>
+    </div>
+  `,
+})
+
+export const Primary = Template.bind({})
+Primary.args = {
+  variant: 'primary',
+  size: 'regular',
+}
+
+export const WithPrependIcon: StoryFn<ButtonProps> = (args) => ({
+  components: { RcSesButtonV2 },
+  setup() {
+    return { args }
+  },
+  template: '<RcSesButtonV2 v-bind="args" prepend-icon="$plus">Button</RcSesButtonV2>',
+})
+WithPrependIcon.args = {
+  variant: 'primary',
+}
+
+export const IconOnly: StoryFn<ButtonProps> = (args) => ({
+  components: { RcSesButtonV2 },
+  setup() {
+    return { args }
+  },
+  template: '<RcSesButtonV2 v-bind="args" icon="$plus" />',
+})
+IconOnly.args = {
+  variant: 'primary',
+  accessibleLabel: 'Add item',
+}
+
+export const Loading: StoryFn<ButtonProps> = (args) => ({
+  components: { RcSesButtonV2 },
+  setup() {
+    return { args }
+  },
+  template: `
+    <div style="display: flex; gap: 12px; flex-wrap: wrap;">
+      <RcSesButtonV2 v-bind="args">Button</RcSesButtonV2>
+      <RcSesButtonV2 v-bind="args" prepend-icon="$plus">Button</RcSesButtonV2>
+      <RcSesButtonV2 v-bind="args" icon="$plus" accessible-label="Add item" />
+    </div>
+  `,
+})
+Loading.args = {
+  variant: 'primary',
+  loading: true,
+}
+
+export const Disabled: StoryFn<ButtonProps> = () => ({
+  components: { RcSesButtonV2 },
+  template: `
+    <div style="display: flex; gap: 12px; flex-wrap: wrap;">
+      <RcSesButtonV2 variant="primary" disabled>Primary</RcSesButtonV2>
+      <RcSesButtonV2 variant="secondary" disabled>Secondary</RcSesButtonV2>
+      <RcSesButtonV2 variant="error" disabled>Error</RcSesButtonV2>
+      <RcSesButtonV2 variant="link" disabled>Link</RcSesButtonV2>
+    </div>
+  `,
+})
+
+export const Small: StoryFn<ButtonProps> = () => ({
+  components: { RcSesButtonV2 },
+  template: `
+    <div style="display: flex; gap: 12px; flex-wrap: wrap; align-items: center;">
+      <RcSesButtonV2 variant="primary" size="small">Button</RcSesButtonV2>
+      <RcSesButtonV2 variant="secondary" size="small">Button</RcSesButtonV2>
+      <RcSesButtonV2 variant="link" size="small">Button</RcSesButtonV2>
+      <RcSesButtonV2 variant="primary" size="small" icon="$plus" accessible-label="Add item" />
+    </div>
+  `,
+})

--- a/src/stories/components v2/Button/Button.stories.ts
+++ b/src/stories/components v2/Button/Button.stories.ts
@@ -1,10 +1,8 @@
-import { StoryFn } from '@storybook/vue3'
+import type { Meta, StoryFn } from '@storybook/vue3'
 
 import RcSesButtonV2 from '@/components/common/buttonV2/RcSesButtonV2.vue'
-import type { ButtonProps } from '@/components/common/buttonV2/types'
 
-export default {
-  components: { RcSesButtonV2 },
+const meta: Meta<typeof RcSesButtonV2> = {
   title: 'components v2/Button',
   component: RcSesButtonV2,
   tags: ['autodocs'],
@@ -26,7 +24,11 @@ export default {
   },
 }
 
-const Template: StoryFn<ButtonProps> = (args) => ({
+export default meta
+
+type Story = StoryFn<typeof RcSesButtonV2>
+
+const Template: Story = (args) => ({
   components: { RcSesButtonV2 },
   setup() {
     return { args }
@@ -53,7 +55,7 @@ Primary.args = {
   size: 'regular',
 }
 
-export const WithPrependIcon: StoryFn<ButtonProps> = (args) => ({
+export const WithPrependIcon: Story = (args) => ({
   components: { RcSesButtonV2 },
   setup() {
     return { args }
@@ -64,7 +66,7 @@ WithPrependIcon.args = {
   variant: 'primary',
 }
 
-export const IconOnly: StoryFn<ButtonProps> = (args) => ({
+export const IconOnly: Story = (args) => ({
   components: { RcSesButtonV2 },
   setup() {
     return { args }
@@ -76,7 +78,7 @@ IconOnly.args = {
   accessibleLabel: 'Add item',
 }
 
-export const Loading: StoryFn<ButtonProps> = (args) => ({
+export const Loading: Story = (args) => ({
   components: { RcSesButtonV2 },
   setup() {
     return { args }
@@ -94,7 +96,7 @@ Loading.args = {
   loading: true,
 }
 
-export const Disabled: StoryFn<ButtonProps> = () => ({
+export const Disabled: Story = () => ({
   components: { RcSesButtonV2 },
   template: `
     <div style="display: flex; gap: 12px; flex-wrap: wrap;">
@@ -106,7 +108,7 @@ export const Disabled: StoryFn<ButtonProps> = () => ({
   `,
 })
 
-export const Small: StoryFn<ButtonProps> = () => ({
+export const Small: Story = () => ({
   components: { RcSesButtonV2 },
   template: `
     <div style="display: flex; gap: 12px; flex-wrap: wrap; align-items: center;">

--- a/src/styles/vuetify/_sizes-v2.scss
+++ b/src/styles/vuetify/_sizes-v2.scss
@@ -7,6 +7,10 @@ $rc-size-v2-primitives: (
   'size-20-v2': 20px,
   'size-24-v2': 24px,
   'size-32-v2': 32px,
+  'size-36-v2': 36px,
+  'size-44-v2': 44px,
+  'size-72-v2': 72px,
+  'size-88-v2': 88px,
 );
 
 $rc-size-v2-semantic: (
@@ -16,6 +20,10 @@ $rc-size-v2-semantic: (
   'icon-medium-v2': 'size-20-v2',
   'icon-large-v2': 'size-24-v2',
   'icon-extra-large-v2': 'size-32-v2',
+  'button-height-small-v2': 'size-36-v2',
+  'button-height-regular-v2': 'size-44-v2',
+  'button-loading-min-width-small-v2': 'size-72-v2',
+  'button-loading-min-width-regular-v2': 'size-88-v2',
 );
 
 @function rc-size-v2($token) {


### PR DESCRIPTION
## 🔗 Task

https://jira.registrucentras.lt/jira/browse/IRM-5283

@tomas562  @saukaite 

## 🧾 Summary

Adds RcSesButtonV2 — v2 design system button (Vuetify v-btn wrapper) with semantic variants (primary, secondary, error, link), two sizes (regular, small), optional prepend/append/icon-only modes, loading spinner, accessibleLabel for a11y, Storybook, and tests.

## 📸 Screenshots

<img width="722" height="287" alt="image" src="https://github.com/user-attachments/assets/96f0c8e5-6624-44be-8f4d-e62f8335945f" />


## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [x] UI matches approved design (Figma)
* [x] Accessibility reviewed (keyboard navigation, labels, semantics)

