### PR TITLE
IRM-5286 (LoaderV2, FullPageLoaderV2)

### DIFF
--- a/src/components/common/FullPageLoaderV2/RcSesFullPageLoaderV2.test.ts
+++ b/src/components/common/FullPageLoaderV2/RcSesFullPageLoaderV2.test.ts
@@ -10,12 +10,16 @@ import { FullPageLoaderBackdrop, type FullPageLoaderProps } from './types'
 const { i18next } = initI18n()
 
 const vOverlayStub = {
-  template: '<div data-testid="full-page-loader-overlay"><slot /></div>',
+  props: ['modelValue'],
+  template:
+    '<div v-if="modelValue" data-testid="full-page-loader-overlay"><slot /></div>',
 }
 
 const vOverlayEmitStub = {
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
   template:
-    '<div data-testid="full-page-loader-overlay" @click="$emit(\'update:modelValue\', false)"><slot /></div>',
+    '<div v-if="modelValue" data-testid="full-page-loader-overlay" @click="$emit(\'update:modelValue\', false)"><slot /></div>',
 }
 
 const renderFullPageLoader = (
@@ -40,6 +44,24 @@ describe('RcSesFullPageLoaderV2', () => {
     ).toBeInTheDocument()
     expect(container.querySelector('.rc-ses-loader-v2--large')).toBeInTheDocument()
     expect(screen.getByText('Kraunama...')).toBeInTheDocument()
+  })
+
+  it('renders when modelValue defaults to true', () => {
+    renderFullPageLoader()
+
+    expect(screen.getByTestId('full-page-loader-overlay')).toBeInTheDocument()
+  })
+
+  it('renders when modelValue is true', () => {
+    renderFullPageLoader({ modelValue: true })
+
+    expect(screen.getByTestId('full-page-loader-overlay')).toBeInTheDocument()
+  })
+
+  it('does not render when modelValue is false', () => {
+    renderFullPageLoader({ modelValue: false })
+
+    expect(screen.queryByTestId('full-page-loader-overlay')).not.toBeInTheDocument()
   })
 
   it('applies backdrop modifier classes', () => {

--- a/src/components/common/FullPageLoaderV2/RcSesFullPageLoaderV2.test.ts
+++ b/src/components/common/FullPageLoaderV2/RcSesFullPageLoaderV2.test.ts
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from '@testing-library/vue'
+import I18NextVue from 'i18next-vue'
+import { describe, expect, it } from 'vitest'
+
+import initI18n from '@/plugins/i18n'
+
+import RcSesFullPageLoaderV2 from './RcSesFullPageLoaderV2.vue'
+import { FullPageLoaderBackdrop, type FullPageLoaderProps } from './types'
+
+const { i18next } = initI18n()
+
+const vOverlayStub = {
+  template: '<div data-testid="full-page-loader-overlay"><slot /></div>',
+}
+
+const vOverlayEmitStub = {
+  template:
+    '<div data-testid="full-page-loader-overlay" @click="$emit(\'update:modelValue\', false)"><slot /></div>',
+}
+
+const renderFullPageLoader = (
+  props: Partial<FullPageLoaderProps> = {},
+  stubs: { VOverlay?: typeof vOverlayStub } = { VOverlay: vOverlayStub },
+) =>
+  render(RcSesFullPageLoaderV2, {
+    props,
+    global: {
+      plugins: [[I18NextVue, { i18next }]],
+      stubs,
+    },
+  })
+
+describe('RcSesFullPageLoaderV2', () => {
+  it('renders the large loader inside the overlay card', () => {
+    const { container } = renderFullPageLoader()
+
+    expect(screen.getByTestId('full-page-loader-overlay')).toBeInTheDocument()
+    expect(
+      container.querySelector('.rc-ses-full-page-loader-v2__card'),
+    ).toBeInTheDocument()
+    expect(container.querySelector('.rc-ses-loader-v2--large')).toBeInTheDocument()
+    expect(screen.getByText('Kraunama...')).toBeInTheDocument()
+  })
+
+  it('applies backdrop modifier classes', () => {
+    const { container: darkContainer } = renderFullPageLoader()
+    const { container: lightContainer } = renderFullPageLoader({
+      backdrop: FullPageLoaderBackdrop.Light,
+    })
+
+    expect(darkContainer.querySelector('.rc-ses-full-page-loader-v2')).toHaveClass(
+      'rc-ses-full-page-loader-v2--dark',
+    )
+    expect(lightContainer.querySelector('.rc-ses-full-page-loader-v2')).toHaveClass(
+      'rc-ses-full-page-loader-v2--light',
+    )
+  })
+
+  it('emits update:modelValue when the overlay closes', async () => {
+    const { emitted } = renderFullPageLoader(
+      { modelValue: true },
+      { VOverlay: vOverlayEmitStub },
+    )
+
+    await fireEvent.click(screen.getByTestId('full-page-loader-overlay'))
+
+    expect(emitted()['update:modelValue']).toEqual([[false]])
+  })
+})

--- a/src/components/common/FullPageLoaderV2/RcSesFullPageLoaderV2.vue
+++ b/src/components/common/FullPageLoaderV2/RcSesFullPageLoaderV2.vue
@@ -8,7 +8,7 @@
     :contained="props.contained"
     persistent
     scrim
-    @update:model-value="handleUpdate"
+    @update:model-value="(value) => (isVisible = value)"
   >
     <div class="rc-ses-full-page-loader-v2__card">
       <RcSesLoaderV2 size="large" :show-label="props.showLabel" :label="props.label" />
@@ -32,11 +32,7 @@ const emit = defineEmits<{
 }>()
 
 const isVisible = computed({
-  get: () => props.modelValue ?? true,
+  get: () => props.modelValue,
   set: (value: boolean) => emit('update:modelValue', value),
 })
-
-const handleUpdate = (value: boolean) => {
-  isVisible.value = value
-}
 </script>

--- a/src/components/common/FullPageLoaderV2/RcSesFullPageLoaderV2.vue
+++ b/src/components/common/FullPageLoaderV2/RcSesFullPageLoaderV2.vue
@@ -1,0 +1,42 @@
+<template>
+  <v-overlay
+    :class="[
+      'rc-ses-full-page-loader-v2',
+      `rc-ses-full-page-loader-v2--${props.backdrop}`,
+    ]"
+    :model-value="isVisible"
+    :contained="props.contained"
+    persistent
+    scrim
+    @update:model-value="handleUpdate"
+  >
+    <div class="rc-ses-full-page-loader-v2__card">
+      <RcSesLoaderV2 size="large" :show-label="props.showLabel" :label="props.label" />
+    </div>
+  </v-overlay>
+</template>
+
+<script setup lang="ts">
+import { computed, withDefaults } from 'vue'
+
+import fullPageLoaderV2Defaults from '@/components/common/FullPageLoaderV2/defaults'
+import type { FullPageLoaderProps } from '@/components/common/FullPageLoaderV2/types'
+import RcSesLoaderV2 from '@/components/common/LoaderV2/RcSesLoaderV2.vue'
+
+import './style.scss'
+
+const props = withDefaults(defineProps<FullPageLoaderProps>(), fullPageLoaderV2Defaults)
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+}>()
+
+const isVisible = computed({
+  get: () => props.modelValue ?? true,
+  set: (value: boolean) => emit('update:modelValue', value),
+})
+
+const handleUpdate = (value: boolean) => {
+  isVisible.value = value
+}
+</script>

--- a/src/components/common/FullPageLoaderV2/defaults.ts
+++ b/src/components/common/FullPageLoaderV2/defaults.ts
@@ -1,0 +1,17 @@
+import { FullPageLoaderBackdrop } from '@/components/common/FullPageLoaderV2/types'
+
+export type FullPageLoaderDefaultsType = {
+  backdrop: `${FullPageLoaderBackdrop}`
+  showLabel: boolean
+  modelValue: boolean
+  contained: boolean
+}
+
+const fullPageLoaderV2Defaults = {
+  backdrop: FullPageLoaderBackdrop.Dark,
+  showLabel: true,
+  modelValue: true,
+  contained: false,
+} satisfies FullPageLoaderDefaultsType
+
+export default fullPageLoaderV2Defaults

--- a/src/components/common/FullPageLoaderV2/style.scss
+++ b/src/components/common/FullPageLoaderV2/style.scss
@@ -1,0 +1,37 @@
+@use '/src/styles/vuetify/borders-v2' as borders-v2;
+@use '/src/styles/vuetify/elevation-v2' as elevation-v2;
+@use '/src/styles/vuetify/spacing-v2' as spacing-v2;
+
+.rc-ses-full-page-loader-v2 {
+  .v-overlay__content {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+  }
+
+  &--dark {
+    .v-overlay__scrim {
+      background: rgba(var(--v-theme-surface-inverse-v2), 0.55) !important;
+      opacity: 1 !important;
+    }
+  }
+
+  &--light {
+    .v-overlay__scrim {
+      background: rgba(var(--v-theme-surface-base-v2), 0.7) !important;
+      opacity: 1 !important;
+    }
+  }
+
+  &__card {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: spacing-v2.rc-spacing-v2('spacing-32-v2');
+    background: rgb(var(--v-theme-surface-base-v2));
+    border-radius: borders-v2.rc-radius-v2('card-radius-v2');
+    box-shadow: elevation-v2.rc-elevation-v2('elevation-md-v2');
+  }
+}

--- a/src/components/common/FullPageLoaderV2/types.ts
+++ b/src/components/common/FullPageLoaderV2/types.ts
@@ -1,0 +1,12 @@
+export enum FullPageLoaderBackdrop {
+  Dark = 'dark',
+  Light = 'light',
+}
+
+export type FullPageLoaderProps = {
+  backdrop?: `${FullPageLoaderBackdrop}`
+  showLabel?: boolean
+  label?: string
+  modelValue?: boolean
+  contained?: boolean
+}

--- a/src/components/common/FullPageLoaderV2/types.ts
+++ b/src/components/common/FullPageLoaderV2/types.ts
@@ -7,6 +7,7 @@ export type FullPageLoaderProps = {
   backdrop?: `${FullPageLoaderBackdrop}`
   showLabel?: boolean
   label?: string
+  /** Controls overlay visibility. Use with `v-model`. */
   modelValue?: boolean
   contained?: boolean
 }

--- a/src/components/common/LoaderV2/RcSesLoaderV2.test.ts
+++ b/src/components/common/LoaderV2/RcSesLoaderV2.test.ts
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/vue'
+import I18NextVue from 'i18next-vue'
+import { describe, expect, it } from 'vitest'
+
+import initI18n from '@/plugins/i18n'
+
+import RcSesLoaderV2 from './RcSesLoaderV2.vue'
+import { type LoaderProps, LoaderSize } from './types'
+
+const { i18next } = initI18n()
+
+const renderLoader = (props: Partial<LoaderProps> = {}) =>
+  render(RcSesLoaderV2, {
+    props,
+    global: {
+      plugins: [[I18NextVue, { i18next }]],
+    },
+  })
+
+describe('RcSesLoaderV2', () => {
+  it('renders with role status and default label', () => {
+    renderLoader()
+
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.getByText('Kraunama...')).toBeInTheDocument()
+  })
+
+  it('applies size modifier classes', () => {
+    const { container: defaultContainer } = renderLoader()
+    const { container: smallContainer } = renderLoader({ size: LoaderSize.Small })
+    const { container: largeContainer } = renderLoader({ size: LoaderSize.Large })
+
+    expect(defaultContainer.querySelector('.rc-ses-loader-v2')).toHaveClass(
+      'rc-ses-loader-v2--medium',
+    )
+    expect(smallContainer.querySelector('.rc-ses-loader-v2')).toHaveClass(
+      'rc-ses-loader-v2--small',
+    )
+    expect(largeContainer.querySelector('.rc-ses-loader-v2')).toHaveClass(
+      'rc-ses-loader-v2--large',
+    )
+  })
+
+  it('renders a custom label when provided', () => {
+    renderLoader({ label: 'Exporting report...' })
+
+    expect(screen.getByText('Exporting report...')).toBeInTheDocument()
+  })
+
+  it('uses aria-label when the visual label is hidden', () => {
+    renderLoader({ showLabel: false })
+
+    expect(screen.queryByText('Kraunama...')).not.toBeInTheDocument()
+    expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'Kraunama...')
+  })
+})

--- a/src/components/common/LoaderV2/RcSesLoaderV2.vue
+++ b/src/components/common/LoaderV2/RcSesLoaderV2.vue
@@ -1,0 +1,42 @@
+<template>
+  <div
+    :class="['rc-ses-loader-v2', `rc-ses-loader-v2--${props.size}`]"
+    role="status"
+    aria-live="polite"
+    :aria-label="accessibleLabel"
+  >
+    <svg
+      class="rc-ses-loader-v2__spinner"
+      viewBox="0 0 48 48"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <circle class="rc-ses-loader-v2__track" cx="24" cy="24" r="20" />
+      <circle class="rc-ses-loader-v2__arc" cx="24" cy="24" r="20" />
+    </svg>
+
+    <p v-if="props.showLabel" class="rc-ses-loader-v2__label">
+      {{ labelText }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useTranslation } from 'i18next-vue'
+import { computed, withDefaults } from 'vue'
+
+import loaderV2Defaults from '@/components/common/LoaderV2/defaults'
+import type { LoaderProps } from '@/components/common/LoaderV2/types'
+
+import './style.scss'
+
+const props = withDefaults(defineProps<LoaderProps>(), loaderV2Defaults)
+
+const { t } = useTranslation()
+
+const labelText = computed(
+  () => props.label ?? t('RcSesLoaderV2.label', { ns: 'components' }),
+)
+
+const accessibleLabel = computed(() => (props.showLabel ? undefined : labelText.value))
+</script>

--- a/src/components/common/LoaderV2/defaults.ts
+++ b/src/components/common/LoaderV2/defaults.ts
@@ -1,0 +1,13 @@
+import { LoaderSize } from '@/components/common/LoaderV2/types'
+
+export type LoaderDefaultsType = {
+  size: `${LoaderSize}`
+  showLabel: boolean
+}
+
+const loaderV2Defaults = {
+  size: LoaderSize.Medium,
+  showLabel: true,
+} satisfies LoaderDefaultsType
+
+export default loaderV2Defaults

--- a/src/components/common/LoaderV2/style.scss
+++ b/src/components/common/LoaderV2/style.scss
@@ -1,0 +1,96 @@
+@use '/src/styles/vuetify/spacing-v2' as spacing-v2;
+@use '/src/styles/vuetify/typography-v2' as typography-v2;
+
+$loader-size-small: 24px;
+$loader-size-medium: 40px;
+$loader-size-large: 64px;
+
+$loader-stroke-small: 2.5px;
+$loader-stroke-medium: 3px;
+$loader-stroke-large: 4px;
+
+@keyframes rc-ses-loader-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.rc-ses-loader-v2 {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: spacing-v2.rc-spacing-v2('spacing-8-v2');
+
+  &__spinner {
+    display: block;
+    transform-origin: center;
+    animation: rc-ses-loader-spin 1s linear infinite;
+  }
+
+  &__track {
+    fill: none;
+    stroke: rgb(var(--v-theme-border-subtle-v2));
+  }
+
+  &__arc {
+    fill: none;
+    stroke: rgb(var(--v-theme-link-text-v2));
+    stroke-linecap: round;
+    stroke-dasharray: 31.4 94.2;
+    transform-origin: center;
+  }
+
+  &__label {
+    @include typography-v2.rc-typography-v2('body-small-v2');
+
+    margin: 0;
+    color: rgb(var(--v-theme-text-secondary-v2));
+    text-align: center;
+  }
+
+  &--small {
+    .rc-ses-loader-v2__spinner {
+      width: $loader-size-small;
+      height: $loader-size-small;
+    }
+
+    .rc-ses-loader-v2__track,
+    .rc-ses-loader-v2__arc {
+      stroke-width: $loader-stroke-small;
+    }
+  }
+
+  &--medium {
+    .rc-ses-loader-v2__spinner {
+      width: $loader-size-medium;
+      height: $loader-size-medium;
+    }
+
+    .rc-ses-loader-v2__track,
+    .rc-ses-loader-v2__arc {
+      stroke-width: $loader-stroke-medium;
+    }
+  }
+
+  &--large {
+    .rc-ses-loader-v2__spinner {
+      width: $loader-size-large;
+      height: $loader-size-large;
+    }
+
+    .rc-ses-loader-v2__track,
+    .rc-ses-loader-v2__arc {
+      stroke-width: $loader-stroke-large;
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rc-ses-loader-v2__spinner {
+    animation: none;
+  }
+}

--- a/src/components/common/LoaderV2/types.ts
+++ b/src/components/common/LoaderV2/types.ts
@@ -1,0 +1,11 @@
+export enum LoaderSize {
+  Small = 'small',
+  Medium = 'medium',
+  Large = 'large',
+}
+
+export type LoaderProps = {
+  size?: `${LoaderSize}`
+  showLabel?: boolean
+  label?: string
+}

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -8,7 +8,9 @@ import RcSesBadgeV2 from '@/components/common/BadgeV2/RcSesBadgeV2.vue'
 import RcSesCardFooterV2 from '@/components/common/CardV2/RcSesCardFooterV2.vue'
 import RcSesCardV2 from '@/components/common/CardV2/RcSesCardV2.vue'
 import RcSesError from '@/components/common/Error/RcSesError.vue'
+import RcSesFullPageLoaderV2 from '@/components/common/FullPageLoaderV2/RcSesFullPageLoaderV2.vue'
 import RcSesImageAndTextV2 from '@/components/common/ImageAndTextV2/RcSesImageAndTextV2.vue'
+import RcSesLoaderV2 from '@/components/common/LoaderV2/RcSesLoaderV2.vue'
 import RcSesReviewCardV2 from '@/components/common/ReviewCardV2/RcSesReviewCardV2.vue'
 import RcSesStepperV2 from '@/components/common/StepperV2/RcSesStepperV2.vue'
 import RcSesSubcardV2 from '@/components/common/SubcardV2/RcSesSubcardV2.vue'
@@ -131,6 +133,8 @@ export function createRcSesComponents(options: object = {}): Plugin<[]> {
 
     app.component('RcSesBadgeV2', RcSesBadgeV2)
     app.component('RcSesImageAndTextV2', RcSesImageAndTextV2)
+    app.component('RcSesLoaderV2', RcSesLoaderV2)
+    app.component('RcSesFullPageLoaderV2', RcSesFullPageLoaderV2)
     app.component('RcSesStepperV2', RcSesStepperV2)
     app.component('RcSesCardV2', RcSesCardV2)
     app.component('RcSesCardFooterV2', RcSesCardFooterV2)
@@ -157,7 +161,7 @@ export {
 
 export { RcSesAlert, RcSesButton }
 export { RcSesBadgeV2, RcSesButtonV2, RcSesToggleV2 }
-export { RcSesImageAndTextV2, RcSesStepperV2 }
+export { RcSesImageAndTextV2, RcSesLoaderV2, RcSesFullPageLoaderV2, RcSesStepperV2 }
 export { RcSesModalV2, RcSesBackdropV2 }
 export { RcSesCardV2, RcSesCardFooterV2, RcSesReviewCardV2, RcSesSubcardV2 }
 export { RcSesCheckbox, RcSesCheckboxField }

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -62,6 +62,10 @@ const i18n = () => {
             edit: 'Redaguoti',
           },
 
+          RcSesLoaderV2: {
+            label: 'Kraunama...',
+          },
+
           RcSesModalV2: {
             actions: {
               destructive: {
@@ -126,6 +130,10 @@ const i18n = () => {
 
           RcSesReviewCardV2: {
             edit: 'Edit',
+          },
+
+          RcSesLoaderV2: {
+            label: 'Loading...',
           },
 
           RcSesModalV2: {

--- a/src/stories/components v2/FullPageLoader/FullPageLoader.stories.ts
+++ b/src/stories/components v2/FullPageLoader/FullPageLoader.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryFn } from '@storybook/vue3'
+import { ref } from 'vue'
 
 import RcSesFullPageLoaderV2 from '@/components/common/FullPageLoaderV2/RcSesFullPageLoaderV2.vue'
 import {
@@ -24,6 +25,14 @@ const meta: Meta<typeof RcSesFullPageLoaderV2> = {
       control: 'text',
       description: 'Custom loading label (defaults to i18n)',
     },
+    modelValue: {
+      control: 'boolean',
+      description: 'Controls overlay visibility (v-model)',
+    },
+    contained: {
+      control: 'boolean',
+      description: 'Position overlay within the parent container',
+    },
   },
 }
 
@@ -34,26 +43,43 @@ type Story = StoryFn<typeof RcSesFullPageLoaderV2>
 const fullPageLoaderDefaultArgs: Partial<FullPageLoaderProps> = {
   backdrop: FullPageLoaderBackdrop.Dark,
   showLabel: true,
+  modelValue: true,
+  contained: true,
 }
 
 export const Dark: Story = (args) => ({
   components: { RcSesFullPageLoaderV2 },
   setup() {
-    return { args }
+    const open = ref(args.modelValue ?? true)
+
+    return { args, open }
   },
   template: `
     <div style="position: relative; height: 360px;">
-      <RcSesFullPageLoaderV2 v-bind="args" contained />
+      <RcSesFullPageLoaderV2 v-bind="args" v-model="open" />
     </div>
   `,
 })
 Dark.args = fullPageLoaderDefaultArgs as Meta<typeof RcSesFullPageLoaderV2>['args']
 
-export const Light: Story = () => ({
+export const Light: Story = (args) => ({
   components: { RcSesFullPageLoaderV2 },
+  setup() {
+    const open = ref(args.modelValue ?? true)
+
+    return { args, open }
+  },
   template: `
     <div style="position: relative; height: 360px;">
-      <RcSesFullPageLoaderV2 backdrop="light" contained />
+      <RcSesFullPageLoaderV2
+        v-bind="args"
+        v-model="open"
+        backdrop="light"
+      />
     </div>
   `,
 })
+Light.args = {
+  ...fullPageLoaderDefaultArgs,
+  backdrop: FullPageLoaderBackdrop.Light,
+} as Meta<typeof RcSesFullPageLoaderV2>['args']

--- a/src/stories/components v2/FullPageLoader/FullPageLoader.stories.ts
+++ b/src/stories/components v2/FullPageLoader/FullPageLoader.stories.ts
@@ -1,0 +1,59 @@
+import type { Meta, StoryFn } from '@storybook/vue3'
+
+import RcSesFullPageLoaderV2 from '@/components/common/FullPageLoaderV2/RcSesFullPageLoaderV2.vue'
+import {
+  FullPageLoaderBackdrop,
+  type FullPageLoaderProps,
+} from '@/components/common/FullPageLoaderV2/types'
+
+const meta: Meta<typeof RcSesFullPageLoaderV2> = {
+  title: 'componentsV2/FullPageLoader',
+  component: RcSesFullPageLoaderV2,
+  tags: ['autodocs'],
+  argTypes: {
+    backdrop: {
+      control: 'select',
+      options: [FullPageLoaderBackdrop.Dark, FullPageLoaderBackdrop.Light],
+      description: 'Overlay scrim variant',
+    },
+    showLabel: {
+      control: 'boolean',
+      description: 'Toggle the loading label below the spinner',
+    },
+    label: {
+      control: 'text',
+      description: 'Custom loading label (defaults to i18n)',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryFn<typeof RcSesFullPageLoaderV2>
+
+const fullPageLoaderDefaultArgs: Partial<FullPageLoaderProps> = {
+  backdrop: FullPageLoaderBackdrop.Dark,
+  showLabel: true,
+}
+
+export const Dark: Story = (args) => ({
+  components: { RcSesFullPageLoaderV2 },
+  setup() {
+    return { args }
+  },
+  template: `
+    <div style="position: relative; height: 360px;">
+      <RcSesFullPageLoaderV2 v-bind="args" contained />
+    </div>
+  `,
+})
+Dark.args = fullPageLoaderDefaultArgs as Meta<typeof RcSesFullPageLoaderV2>['args']
+
+export const Light: Story = () => ({
+  components: { RcSesFullPageLoaderV2 },
+  template: `
+    <div style="position: relative; height: 360px;">
+      <RcSesFullPageLoaderV2 backdrop="light" contained />
+    </div>
+  `,
+})

--- a/src/stories/components v2/Loader/Loader.stories.ts
+++ b/src/stories/components v2/Loader/Loader.stories.ts
@@ -1,0 +1,69 @@
+import type { Meta, StoryFn } from '@storybook/vue3'
+
+import RcSesLoaderV2 from '@/components/common/LoaderV2/RcSesLoaderV2.vue'
+import { type LoaderProps, LoaderSize } from '@/components/common/LoaderV2/types'
+
+const meta: Meta<typeof RcSesLoaderV2> = {
+  title: 'componentsV2/Loader',
+  component: RcSesLoaderV2,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: [LoaderSize.Small, LoaderSize.Medium, LoaderSize.Large],
+      description: 'Spinner dimensions (24px / 40px / 64px)',
+    },
+    showLabel: {
+      control: 'boolean',
+      description: 'Toggle the loading label below the spinner',
+    },
+    label: {
+      control: 'text',
+      description: 'Custom loading label (defaults to i18n)',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryFn<typeof RcSesLoaderV2>
+
+const loaderDefaultArgs: Partial<LoaderProps> = {
+  size: LoaderSize.Medium,
+  showLabel: true,
+}
+
+export const Default: Story = (args) => ({
+  components: { RcSesLoaderV2 },
+  setup() {
+    return { args }
+  },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <RcSesLoaderV2 v-bind="args" />
+      </div>
+    </div>
+  `,
+})
+Default.args = loaderDefaultArgs as Meta<typeof RcSesLoaderV2>['args']
+
+export const Small: Story = () => ({
+  components: { RcSesLoaderV2 },
+  template: `<RcSesLoaderV2 size="small" />`,
+})
+
+export const Medium: Story = () => ({
+  components: { RcSesLoaderV2 },
+  template: `<RcSesLoaderV2 size="medium" />`,
+})
+
+export const Large: Story = () => ({
+  components: { RcSesLoaderV2 },
+  template: `<RcSesLoaderV2 size="large" />`,
+})
+
+export const WithoutLabel: Story = () => ({
+  components: { RcSesLoaderV2 },
+  template: `<RcSesLoaderV2 :show-label="false" />`,
+})


### PR DESCRIPTION
## 🔗 Task

https://jira.registrucentras.lt/jira/browse/IRM-5286

@tomas562  @saukaite 

## 🧾 Summary

Adds RcSesLoaderV2 — v2 loading spinner with small / medium / large sizes (24px / 40px / 64px), optional label (default via i18n), and accessibility support (role="status", aria-live, aria-label when label is hidden). Styling uses v2 tokens; animation respects prefers-reduced-motion. Includes LoaderSize enum, Storybook, tests, and library export.

Adds RcSesFullPageLoaderV2 — v2 full-page loading overlay built on v-overlay that composes RcSesLoaderV2 (large) inside a centered card, with dark / light backdrop variants, v-model visibility control, and contained mode for scoped previews. Includes FullPageLoaderBackdrop enum, Storybook, tests, and library export.

## 📸 Screenshots
<img width="925" height="512" alt="image" src="https://github.com/user-attachments/assets/5ad8d086-fd43-423c-94b1-e9c3d7c71dd0" />
<img width="923" height="780" alt="image" src="https://github.com/user-attachments/assets/2b6853b1-0a46-4661-850a-cc02b2a51b43" />


## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [x] UI matches approved design (Figma)
* [x] Accessibility reviewed (keyboard navigation, labels, semantics)
