### PR TITLE
IRM-5290 (InlineAlertV2)

### DIFF
--- a/src/components/common/InlineAlertV2/RcSesInlineAlertV2.test.ts
+++ b/src/components/common/InlineAlertV2/RcSesInlineAlertV2.test.ts
@@ -97,4 +97,32 @@ describe('RcSesInlineAlertV2', () => {
 
     expect(emitted().action).toEqual([[]])
   })
+
+  it('does not render close button when showClose is false', () => {
+    renderInlineAlert({ showClose: false })
+
+    expect(screen.queryByRole('button', { name: 'Uždaryti' })).not.toBeInTheDocument()
+  })
+
+  it('supports keyboard navigation between action and close buttons', () => {
+    const { container } = renderInlineAlert({
+      showAction: true,
+      actionLabel: 'Peržiūrėti',
+      showClose: true,
+    })
+
+    const actionButton = screen.getByRole('button', { name: 'Peržiūrėti' })
+    const closeButton = screen.getByRole('button', { name: 'Uždaryti' })
+    const buttons = Array.from(container.querySelectorAll('button[type="button"]'))
+
+    expect(buttons).toHaveLength(2)
+    expect(buttons[0]).toBe(actionButton)
+    expect(buttons[1]).toBe(closeButton)
+
+    actionButton.focus()
+    expect(document.activeElement).toBe(actionButton)
+
+    closeButton.focus()
+    expect(document.activeElement).toBe(closeButton)
+  })
 })

--- a/src/components/common/InlineAlertV2/RcSesInlineAlertV2.test.ts
+++ b/src/components/common/InlineAlertV2/RcSesInlineAlertV2.test.ts
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen } from '@testing-library/vue'
+import I18NextVue from 'i18next-vue'
+import { describe, expect, it } from 'vitest'
+
+import initI18n from '@/plugins/i18n'
+
+import RcSesInlineAlertV2 from './RcSesInlineAlertV2.vue'
+import { type InlineAlertProps, InlineAlertType } from './types'
+
+const { i18next } = initI18n()
+
+const defaultMessage = 'Pranešimo tekstas. Pakeisk turinį pagal kontekstą.'
+
+const renderInlineAlert = (
+  props: Partial<InlineAlertProps> = {},
+  slots: Record<string, string> = {},
+) =>
+  render(RcSesInlineAlertV2, {
+    props: {
+      message: defaultMessage,
+      ...props,
+    },
+    slots,
+    global: {
+      plugins: [[I18NextVue, { i18next }]],
+      stubs: {
+        RcSesButtonV2: {
+          props: ['variant', 'size'],
+          emits: ['click'],
+          template: `
+            <button type="button" :data-variant="variant" @click="$emit('click')">
+              <slot />
+            </button>
+          `,
+        },
+      },
+    },
+  })
+
+describe('RcSesInlineAlertV2', () => {
+  it('renders the message text', () => {
+    renderInlineAlert()
+
+    expect(screen.getByText(defaultMessage)).toBeInTheDocument()
+  })
+
+  it('applies type modifier classes', () => {
+    const { container } = renderInlineAlert({ type: InlineAlertType.Warning })
+
+    expect(container.querySelector('.rc-ses-inline-alert-v2')).toHaveClass(
+      'rc-ses-inline-alert-v2--warning',
+    )
+  })
+
+  it('uses role status and polite live region for info alerts', () => {
+    const { container } = renderInlineAlert({ type: InlineAlertType.Info })
+
+    const alert = container.querySelector('.rc-ses-inline-alert-v2')
+    expect(alert).toHaveAttribute('role', 'status')
+    expect(alert).toHaveAttribute('aria-live', 'polite')
+  })
+
+  it('uses role alert and assertive live region for error alerts', () => {
+    const { container } = renderInlineAlert({ type: InlineAlertType.Error })
+
+    const alert = container.querySelector('.rc-ses-inline-alert-v2')
+    expect(alert).toHaveAttribute('role', 'alert')
+    expect(alert).toHaveAttribute('aria-live', 'assertive')
+  })
+
+  it('hides the status icon when showIcon is false', () => {
+    const { container } = renderInlineAlert({ showIcon: false })
+
+    expect(
+      container.querySelector('.rc-ses-inline-alert-v2__icon'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('emits close when the dismiss button is clicked', async () => {
+    const { emitted } = renderInlineAlert()
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Uždaryti' }))
+
+    expect(emitted().close).toEqual([[]])
+  })
+
+  it('renders and emits action when showAction is true', async () => {
+    const { emitted } = renderInlineAlert({
+      showAction: true,
+      actionLabel: 'Peržiūrėti',
+    })
+
+    const actionButton = screen.getByRole('button', { name: 'Peržiūrėti' })
+    expect(actionButton).toHaveAttribute('data-variant', 'link')
+
+    await fireEvent.click(actionButton)
+
+    expect(emitted().action).toEqual([[]])
+  })
+})

--- a/src/components/common/InlineAlertV2/RcSesInlineAlertV2.vue
+++ b/src/components/common/InlineAlertV2/RcSesInlineAlertV2.vue
@@ -1,0 +1,71 @@
+<template>
+  <div
+    :class="['rc-ses-inline-alert-v2', `rc-ses-inline-alert-v2--${props.type}`]"
+    :role="alertRole"
+    :aria-live="ariaLive"
+  >
+    <slot v-if="props.showIcon" name="icon">
+      <v-icon
+        class="rc-ses-inline-alert-v2__icon"
+        :icon="statusIcon"
+        aria-hidden="true"
+      />
+    </slot>
+
+    <p class="rc-ses-inline-alert-v2__message">
+      <slot>{{ props.message }}</slot>
+    </p>
+
+    <div v-if="props.showAction" class="rc-ses-inline-alert-v2__action">
+      <slot name="action">
+        <RcSesButtonV2 variant="link" size="small" @click="emit('action')">
+          {{ props.actionLabel }}
+        </RcSesButtonV2>
+      </slot>
+    </div>
+
+    <button
+      v-if="props.showClose"
+      type="button"
+      class="rc-ses-inline-alert-v2__close"
+      :aria-label="closeAriaLabel"
+      @click="emit('close')"
+    >
+      <v-icon icon="$close" aria-hidden="true" />
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useTranslation } from 'i18next-vue'
+import { computed, withDefaults } from 'vue'
+
+import inlineAlertV2Defaults from '@/components/common/InlineAlertV2/defaults'
+import {
+  assertiveInlineAlertTypes,
+  inlineAlertIcons,
+} from '@/components/common/InlineAlertV2/iconConfig'
+import type { InlineAlertProps } from '@/components/common/InlineAlertV2/types'
+import RcSesButtonV2 from '@/components/common/buttonV2/RcSesButtonV2.vue'
+
+import './style.scss'
+
+const props = withDefaults(defineProps<InlineAlertProps>(), inlineAlertV2Defaults)
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'action'): void
+}>()
+
+const { t } = useTranslation()
+
+const isAssertive = computed(() => assertiveInlineAlertTypes.has(props.type))
+
+const alertRole = computed(() => (isAssertive.value ? 'alert' : 'status'))
+
+const ariaLive = computed(() => (isAssertive.value ? 'assertive' : 'polite'))
+
+const statusIcon = computed(() => inlineAlertIcons[props.type])
+
+const closeAriaLabel = computed(() => t('RcSesInlineAlertV2.close', { ns: 'components' }))
+</script>

--- a/src/components/common/InlineAlertV2/defaults.ts
+++ b/src/components/common/InlineAlertV2/defaults.ts
@@ -1,0 +1,19 @@
+import { InlineAlertType } from '@/components/common/InlineAlertV2/types'
+
+export type InlineAlertDefaultsType = {
+  type: `${InlineAlertType}`
+  showIcon: boolean
+  showClose: boolean
+  showAction: boolean
+  actionLabel: string
+}
+
+const inlineAlertV2Defaults = {
+  type: InlineAlertType.Neutral,
+  showIcon: true,
+  showClose: true,
+  showAction: false,
+  actionLabel: '',
+} satisfies InlineAlertDefaultsType
+
+export default inlineAlertV2Defaults

--- a/src/components/common/InlineAlertV2/iconConfig.ts
+++ b/src/components/common/InlineAlertV2/iconConfig.ts
@@ -1,0 +1,14 @@
+import { InlineAlertType } from '@/components/common/InlineAlertV2/types'
+
+export const inlineAlertIcons: Record<`${InlineAlertType}`, string> = {
+  [InlineAlertType.Neutral]: '$infoRegular',
+  [InlineAlertType.Info]: '$infoRegular',
+  [InlineAlertType.Success]: '$checkCircle',
+  [InlineAlertType.Warning]: '$warningRegular',
+  [InlineAlertType.Error]: '$warningCircle',
+}
+
+export const assertiveInlineAlertTypes = new Set<`${InlineAlertType}`>([
+  InlineAlertType.Warning,
+  InlineAlertType.Error,
+])

--- a/src/components/common/InlineAlertV2/style.scss
+++ b/src/components/common/InlineAlertV2/style.scss
@@ -1,0 +1,108 @@
+@use '/src/styles/vuetify/borders-v2' as borders-v2;
+@use '/src/styles/vuetify/sizes-v2' as sizes-v2;
+@use '/src/styles/vuetify/spacing-v2' as spacing-v2;
+@use '/src/styles/vuetify/typography-v2' as typography-v2;
+
+.rc-ses-inline-alert-v2 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: spacing-v2.rc-spacing-v2('spacing-12-v2');
+  min-height: sizes-v2.rc-size-v2('button-height-regular-v2');
+  padding: spacing-v2.rc-spacing-v2('spacing-12-v2') spacing-v2.rc-spacing-v2('spacing-16-v2');
+  border: borders-v2.rc-stroke-v2('border-width-default-v2') solid;
+  border-radius: borders-v2.rc-radius-v2('radius-8-v2');
+
+  &__icon {
+    flex-shrink: 0;
+    @include sizes-v2.rc-icon-size-v2('icon-medium-v2');
+  }
+
+  &__message {
+    @include typography-v2.rc-typography-v2('body-small-v2');
+
+    flex: 1 1 auto;
+    margin: 0;
+    min-width: 0;
+  }
+
+  &__action {
+    flex-shrink: 0;
+
+    .rc-ses-button-v2--link {
+      color: inherit;
+    }
+  }
+
+  &__close {
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    line-height: 0;
+
+    @include sizes-v2.rc-icon-size-v2('icon-medium-v2');
+
+    &:focus-visible {
+      outline: 2px solid rgb(var(--v-theme-border-focus-actual-v2));
+      outline-offset: 1px;
+      border-radius: borders-v2.rc-radius-v2('radius-4-v2');
+    }
+  }
+
+  &--neutral {
+    background-color: rgb(var(--v-theme-surface-sunken-v2));
+    border-color: rgb(var(--v-theme-border-subtle-v2));
+    color: rgb(var(--v-theme-text-primary-v2));
+
+    .rc-ses-inline-alert-v2__icon {
+      color: rgb(var(--v-theme-text-secondary-v2));
+    }
+  }
+
+  &--info {
+    background-color: rgb(var(--v-theme-info-bg-v2));
+    border-color: rgb(var(--v-theme-info-border-v2));
+    color: rgb(var(--v-theme-info-text-v2));
+
+    .rc-ses-inline-alert-v2__icon {
+      color: rgb(var(--v-theme-info-icon-v2));
+    }
+  }
+
+  &--success {
+    background-color: rgb(var(--v-theme-success-bg-v2));
+    border-color: rgb(var(--v-theme-success-border-v2));
+    color: rgb(var(--v-theme-success-text-v2));
+
+    .rc-ses-inline-alert-v2__icon {
+      color: rgb(var(--v-theme-success-icon-v2));
+    }
+  }
+
+  &--warning {
+    background-color: rgb(var(--v-theme-warning-bg-v2));
+    border-color: rgb(var(--v-theme-warning-border-v2));
+    color: rgb(var(--v-theme-warning-text-v2));
+
+    .rc-ses-inline-alert-v2__icon {
+      color: rgb(var(--v-theme-warning-icon-v2));
+    }
+  }
+
+  &--error {
+    background-color: rgb(var(--v-theme-error-bg-v2));
+    border-color: rgb(var(--v-theme-error-border-v2));
+    color: rgb(var(--v-theme-error-text-v2));
+
+    .rc-ses-inline-alert-v2__icon {
+      color: rgb(var(--v-theme-error-icon-v2));
+    }
+  }
+}

--- a/src/components/common/InlineAlertV2/style.scss
+++ b/src/components/common/InlineAlertV2/style.scss
@@ -25,6 +25,7 @@
     flex: 1 1 auto;
     margin: 0;
     min-width: 0;
+    overflow-wrap: break-word;
   }
 
   &__action {

--- a/src/components/common/InlineAlertV2/types.ts
+++ b/src/components/common/InlineAlertV2/types.ts
@@ -1,0 +1,16 @@
+export enum InlineAlertType {
+  Neutral = 'neutral',
+  Info = 'info',
+  Success = 'success',
+  Warning = 'warning',
+  Error = 'error',
+}
+
+export type InlineAlertProps = {
+  type?: `${InlineAlertType}`
+  message?: string
+  showIcon?: boolean
+  showClose?: boolean
+  showAction?: boolean
+  actionLabel?: string
+}

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -9,6 +9,7 @@ import RcSesCardFooterV2 from '@/components/common/CardV2/RcSesCardFooterV2.vue'
 import RcSesCardV2 from '@/components/common/CardV2/RcSesCardV2.vue'
 import RcSesError from '@/components/common/Error/RcSesError.vue'
 import RcSesImageAndTextV2 from '@/components/common/ImageAndTextV2/RcSesImageAndTextV2.vue'
+import RcSesInlineAlertV2 from '@/components/common/InlineAlertV2/RcSesInlineAlertV2.vue'
 import RcSesReviewCardV2 from '@/components/common/ReviewCardV2/RcSesReviewCardV2.vue'
 import RcSesStepperV2 from '@/components/common/StepperV2/RcSesStepperV2.vue'
 import RcSesSubcardV2 from '@/components/common/SubcardV2/RcSesSubcardV2.vue'
@@ -131,6 +132,7 @@ export function createRcSesComponents(options: object = {}): Plugin<[]> {
 
     app.component('RcSesBadgeV2', RcSesBadgeV2)
     app.component('RcSesImageAndTextV2', RcSesImageAndTextV2)
+    app.component('RcSesInlineAlertV2', RcSesInlineAlertV2)
     app.component('RcSesStepperV2', RcSesStepperV2)
     app.component('RcSesCardV2', RcSesCardV2)
     app.component('RcSesCardFooterV2', RcSesCardFooterV2)
@@ -157,7 +159,7 @@ export {
 
 export { RcSesAlert, RcSesButton }
 export { RcSesBadgeV2, RcSesButtonV2, RcSesToggleV2 }
-export { RcSesImageAndTextV2, RcSesStepperV2 }
+export { RcSesImageAndTextV2, RcSesInlineAlertV2, RcSesStepperV2 }
 export { RcSesModalV2, RcSesBackdropV2 }
 export { RcSesCardV2, RcSesCardFooterV2, RcSesReviewCardV2, RcSesSubcardV2 }
 export { RcSesCheckbox, RcSesCheckboxField }

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -45,6 +45,10 @@ const i18n = () => {
             remove: 'Pašalinti',
           },
 
+          RcSesInlineAlertV2: {
+            close: 'Uždaryti',
+          },
+
           RcSesStepperV2: {
             back: 'Grįžti',
             completedStep: 'Užbaigta: {{step}}',
@@ -109,6 +113,10 @@ const i18n = () => {
 
           RcSesBadgeV2: {
             remove: 'Remove',
+          },
+
+          RcSesInlineAlertV2: {
+            close: 'Close',
           },
 
           RcSesStepperV2: {

--- a/src/stories/components v2/InlineAlert/InlineAlert.stories.ts
+++ b/src/stories/components v2/InlineAlert/InlineAlert.stories.ts
@@ -1,0 +1,125 @@
+import type { Meta, StoryFn } from '@storybook/vue3'
+
+import RcSesInlineAlertV2 from '@/components/common/InlineAlertV2/RcSesInlineAlertV2.vue'
+import {
+  type InlineAlertProps,
+  InlineAlertType,
+} from '@/components/common/InlineAlertV2/types'
+
+const defaultMessage =
+  'Alert message. Replace this text with content relevant to your context.'
+const defaultActionLabel = 'View details'
+
+const meta: Meta<typeof RcSesInlineAlertV2> = {
+  title: 'componentsV2/InlineAlert',
+  component: RcSesInlineAlertV2,
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: 'select',
+      options: [
+        InlineAlertType.Neutral,
+        InlineAlertType.Info,
+        InlineAlertType.Success,
+        InlineAlertType.Warning,
+        InlineAlertType.Error,
+      ],
+      description: 'Semantic alert type',
+    },
+    showIcon: {
+      control: 'boolean',
+      description: 'Toggle the leading status icon',
+    },
+    showClose: {
+      control: 'boolean',
+      description: 'Toggle the dismiss close button',
+    },
+    showAction: {
+      control: 'boolean',
+      description: 'Toggle the trailing link action',
+    },
+    message: {
+      control: 'text',
+      description: 'Alert message text',
+    },
+    actionLabel: {
+      control: 'text',
+      description: 'Link action label',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryFn<typeof RcSesInlineAlertV2>
+
+const inlineAlertDefaultArgs: Partial<InlineAlertProps> = {
+  type: InlineAlertType.Neutral,
+  message: defaultMessage,
+  showIcon: true,
+  showClose: true,
+  showAction: false,
+}
+
+export const Default: Story = (args) => ({
+  components: { RcSesInlineAlertV2 },
+  setup() {
+    return { args }
+  },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <RcSesInlineAlertV2 v-bind="args" />
+      </div>
+    </div>
+  `,
+})
+Default.args = inlineAlertDefaultArgs as Meta<typeof RcSesInlineAlertV2>['args']
+
+export const AllTypes: Story = () => ({
+  components: { RcSesInlineAlertV2 },
+  setup() {
+    return {
+      defaultMessage,
+      InlineAlertType,
+    }
+  },
+  template: `
+    <div style="display: flex; flex-direction: column; gap: 16px; max-width: 560px;">
+      <RcSesInlineAlertV2 :type="InlineAlertType.Neutral" :message="defaultMessage" />
+      <RcSesInlineAlertV2 :type="InlineAlertType.Info" :message="defaultMessage" />
+      <RcSesInlineAlertV2 :type="InlineAlertType.Success" :message="defaultMessage" />
+      <RcSesInlineAlertV2 :type="InlineAlertType.Warning" :message="defaultMessage" />
+      <RcSesInlineAlertV2 :type="InlineAlertType.Error" :message="defaultMessage" />
+    </div>
+  `,
+})
+
+export const WithAction: Story = () => ({
+  components: { RcSesInlineAlertV2 },
+  setup() {
+    return { defaultMessage, defaultActionLabel }
+  },
+  template: `
+    <RcSesInlineAlertV2
+      type="info"
+      :message="defaultMessage"
+      show-action
+      :action-label="defaultActionLabel"
+    />
+  `,
+})
+
+export const WithoutIcon: Story = () => ({
+  components: { RcSesInlineAlertV2 },
+  setup() {
+    return { defaultMessage }
+  },
+  template: `
+    <RcSesInlineAlertV2
+      type="warning"
+      :message="defaultMessage"
+      :show-icon="false"
+    />
+  `,
+})

--- a/src/stories/components v2/InlineAlert/InlineAlert.stories.ts
+++ b/src/stories/components v2/InlineAlert/InlineAlert.stories.ts
@@ -8,6 +8,8 @@ import {
 
 const defaultMessage =
   'Alert message. Replace this text with content relevant to your context.'
+const longMessage =
+  'This is a very long alert message intended to demonstrate how InlineAlertV2 handles extended content without breaking the layout. It should wrap naturally across multiple lines while keeping the icon, action link, and close button aligned. Replace this placeholder copy with context-specific content from your application.'
 const defaultActionLabel = 'View details'
 
 const meta: Meta<typeof RcSesInlineAlertV2> = {
@@ -121,5 +123,22 @@ export const WithoutIcon: Story = () => ({
       :message="defaultMessage"
       :show-icon="false"
     />
+  `,
+})
+
+export const LongMessage: Story = () => ({
+  components: { RcSesInlineAlertV2 },
+  setup() {
+    return { longMessage, defaultActionLabel }
+  },
+  template: `
+    <div style="max-width: 560px;">
+      <RcSesInlineAlertV2
+        type="info"
+        :message="longMessage"
+        show-action
+        :action-label="defaultActionLabel"
+      />
+    </div>
   `,
 })


### PR DESCRIPTION
## 🔗 Task

https://jira.registrucentras.lt/jira/browse/IRM-5290

@tomas562  @saukaite 

## 🧾 Summary

Adds RcSesInlineAlertV2 — v2 inline alert with five semantic types (neutral, info, success, warning, error), optional status icon, dismiss close button, and optional link action. Styling uses v2 tokens; accessibility uses role="status" / aria-live="polite" for neutral/info/success and role="alert" / aria-live="assertive" for warning/error. Includes InlineAlertType enum, Storybook, tests, i18n, and library export.

## 📸 Screenshots

<img width="1045" height="642" alt="image" src="https://github.com/user-attachments/assets/d1ef9323-3a55-407b-a2f4-3f15891787e7" />


## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [x] UI matches approved design (Figma)
* [x] Accessibility reviewed (keyboard navigation, labels, semantics)
