### PR TITLE
IRM-5291 (SnackbarV2)

### DIFF
--- a/src/components/common/SnackbarV2/RcSesSnackbarV2.test.ts
+++ b/src/components/common/SnackbarV2/RcSesSnackbarV2.test.ts
@@ -115,6 +115,15 @@ describe('RcSesSnackbarV2', () => {
     expect(emitted()['update:modelValue']).toEqual([[false]])
   })
 
+  it('emits update:modelValue once when Vuetify closes the snackbar', async () => {
+    const { emitted } = renderSnackbar()
+
+    await fireEvent.keyDown(screen.getByTestId('v-snackbar'), { key: 'Escape' })
+
+    expect(emitted()['update:modelValue']).toEqual([[false]])
+    expect(emitted().close).toEqual([[]])
+  })
+
   it('emits action and closes when dismissOnAction is true', async () => {
     const { emitted } = renderSnackbar({
       showAction: true,

--- a/src/components/common/SnackbarV2/RcSesSnackbarV2.test.ts
+++ b/src/components/common/SnackbarV2/RcSesSnackbarV2.test.ts
@@ -1,0 +1,159 @@
+import { fireEvent, render, screen } from '@testing-library/vue'
+import I18NextVue from 'i18next-vue'
+import { describe, expect, it } from 'vitest'
+
+import initI18n from '@/plugins/i18n'
+
+import RcSesSnackbarV2 from './RcSesSnackbarV2.vue'
+import { type SnackbarProps, SnackbarState } from './types'
+
+const { i18next } = initI18n()
+
+const defaultMessage = 'Trumpas informacinis tekstas.'
+
+const renderSnackbar = (props: Partial<SnackbarProps> = {}) =>
+  render(RcSesSnackbarV2, {
+    props: {
+      state: SnackbarState.Success,
+      message: defaultMessage,
+      modelValue: true,
+      ...props,
+    },
+    global: {
+      plugins: [[I18NextVue, { i18next }]],
+      stubs: {
+        VSnackbar: {
+          props: ['modelValue', 'timeout', 'location', 'contained'],
+          emits: ['update:modelValue'],
+          template: `
+            <div
+              v-if="modelValue"
+              data-testid="v-snackbar"
+              :data-timeout="timeout"
+              @keydown="$event.key === 'Escape' && $emit('update:modelValue', false)"
+            >
+              <slot />
+            </div>
+          `,
+        },
+        VIcon: {
+          props: ['icon'],
+          template: '<span :data-icon="icon" />',
+        },
+        RcSesButtonV2: {
+          props: ['variant', 'size'],
+          emits: ['click'],
+          template: `
+            <button type="button" :data-variant="variant" @click="$emit('click')">
+              <slot />
+            </button>
+          `,
+        },
+      },
+    },
+  })
+
+describe('RcSesSnackbarV2', () => {
+  it('renders the message text', () => {
+    renderSnackbar()
+
+    expect(screen.getByText(defaultMessage)).toBeInTheDocument()
+  })
+
+  it('applies with-action modifier when showAction is true', () => {
+    const { container } = renderSnackbar({
+      showAction: true,
+      actionLabel: 'Button',
+    })
+
+    expect(container.querySelector('.rc-ses-snackbar-v2')).toHaveClass(
+      'rc-ses-snackbar-v2--with-action',
+    )
+  })
+
+  it('uses role status and polite live region for success snackbars', () => {
+    const { container } = renderSnackbar({ state: SnackbarState.Success })
+
+    const snackbar = container.querySelector('.rc-ses-snackbar-v2')
+    expect(snackbar).toHaveAttribute('role', 'status')
+    expect(snackbar).toHaveAttribute('aria-live', 'polite')
+    expect(snackbar).toHaveAttribute('aria-atomic', 'true')
+  })
+
+  it('uses role alert and assertive live region for error snackbars', () => {
+    const { container } = renderSnackbar({ state: SnackbarState.Error })
+
+    const snackbar = container.querySelector('.rc-ses-snackbar-v2')
+    expect(snackbar).toHaveAttribute('role', 'alert')
+    expect(snackbar).toHaveAttribute('aria-live', 'assertive')
+  })
+
+  it('renders action button when showAction is true', () => {
+    renderSnackbar({
+      showAction: true,
+      actionLabel: 'Button',
+    })
+
+    expect(screen.getByRole('button', { name: 'Button' })).toBeInTheDocument()
+  })
+
+  it('does not render action button when showAction is false', () => {
+    renderSnackbar({
+      showAction: false,
+      actionLabel: 'Button',
+    })
+
+    expect(screen.queryByRole('button', { name: 'Button' })).not.toBeInTheDocument()
+  })
+
+  it('emits close when the dismiss button is clicked', async () => {
+    const { emitted } = renderSnackbar()
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Uždaryti' }))
+
+    expect(emitted().close).toEqual([[]])
+    expect(emitted()['update:modelValue']).toEqual([[false]])
+  })
+
+  it('emits action and closes when dismissOnAction is true', async () => {
+    const { emitted } = renderSnackbar({
+      showAction: true,
+      actionLabel: 'Button',
+      dismissOnAction: true,
+    })
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Button' }))
+
+    expect(emitted().action).toEqual([[]])
+    expect(emitted().close).toEqual([[]])
+  })
+
+  it('does not auto-hide when persist is true', () => {
+    renderSnackbar({ persist: true, duration: 1000 })
+
+    expect(screen.getByTestId('v-snackbar')).toHaveAttribute('data-timeout', '-1')
+  })
+
+  it('shows the full message when showAction is false', () => {
+    const longMessage = 'a'.repeat(80)
+
+    renderSnackbar({
+      showAction: false,
+      message: longMessage,
+    })
+
+    expect(screen.getByText(longMessage)).toBeInTheDocument()
+  })
+
+  it('truncates long messages when showAction is true', () => {
+    const longMessage = 'a'.repeat(130)
+
+    renderSnackbar({
+      showAction: true,
+      actionLabel: 'Button',
+      message: longMessage,
+    })
+
+    expect(screen.getByText(`${'a'.repeat(120)}...`)).toBeInTheDocument()
+  })
+})

--- a/src/components/common/SnackbarV2/RcSesSnackbarV2.vue
+++ b/src/components/common/SnackbarV2/RcSesSnackbarV2.vue
@@ -1,0 +1,178 @@
+<template>
+  <v-snackbar
+    v-model="isOpen"
+    class="rc-ses-snackbar-v2-host"
+    :timeout="snackbarTimeout"
+    location="bottom"
+    :contained="props.contained"
+    @update:model-value="handleVisibilityChange"
+  >
+    <div
+      :class="[
+        'rc-ses-snackbar-v2',
+        `rc-ses-snackbar-v2--${props.state}`,
+        { 'rc-ses-snackbar-v2--with-action': showActionButton },
+      ]"
+      :role="alertRole"
+      :aria-live="ariaLive"
+      aria-atomic="true"
+      @mouseenter="isPaused = true"
+      @mouseleave="isPaused = false"
+      @focusin="isPaused = true"
+      @focusout="handleFocusOut"
+      @keydown.esc.prevent="handleClose"
+    >
+      <div class="rc-ses-snackbar-v2__state">
+        <v-icon
+          :class="[
+            'rc-ses-snackbar-v2__icon',
+            `rc-ses-snackbar-v2__icon--${props.state}`,
+          ]"
+          :icon="statusIcon"
+          aria-hidden="true"
+        />
+
+        <p class="rc-ses-snackbar-v2__message">
+          <slot>{{ displayMessage }}</slot>
+        </p>
+      </div>
+
+      <div v-if="showActions" class="rc-ses-snackbar-v2__actions">
+        <div v-if="showActionButton" class="rc-ses-snackbar-v2__action">
+          <slot name="action">
+            <RcSesButtonV2 variant="secondary" size="small" @click="handleAction">
+              {{ props.actionLabel }}
+            </RcSesButtonV2>
+          </slot>
+        </div>
+
+        <button
+          v-if="props.showClose"
+          type="button"
+          class="rc-ses-snackbar-v2__close"
+          :aria-label="closeAriaLabel"
+          @click="handleClose"
+        >
+          <v-icon icon="$close" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  </v-snackbar>
+</template>
+
+<script setup lang="ts">
+import { useTranslation } from 'i18next-vue'
+import { computed, ref, useSlots } from 'vue'
+
+import {
+  SNACKBAR_CHAR_LIMIT_WITH_ACTION,
+  assertiveSnackbarStates,
+  snackbarIcons,
+} from '@/components/common/SnackbarV2/config'
+import snackbarV2Defaults from '@/components/common/SnackbarV2/defaults'
+import type { SnackbarProps } from '@/components/common/SnackbarV2/types'
+import { SnackbarState } from '@/components/common/SnackbarV2/types'
+import RcSesButtonV2 from '@/components/common/buttonV2/RcSesButtonV2.vue'
+
+import './style.scss'
+
+const props = withDefaults(defineProps<SnackbarProps>(), snackbarV2Defaults)
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'close'): void
+  (e: 'action'): void
+}>()
+
+const { t } = useTranslation()
+const slots = useSlots()
+
+const isPaused = ref(false)
+
+const isPersisted = computed(
+  () => props.persist ?? props.state === SnackbarState.ActionNeeded,
+)
+
+const isOpen = computed({
+  get: () => props.modelValue,
+  set: (value: boolean) => {
+    emit('update:modelValue', value)
+  },
+})
+
+const snackbarTimeout = computed(() => {
+  if (isPersisted.value || isPaused.value) {
+    return -1
+  }
+
+  return props.duration
+})
+
+const isAssertive = computed(() => assertiveSnackbarStates.has(props.state))
+
+const alertRole = computed(() => (isAssertive.value ? 'alert' : 'status'))
+
+const ariaLive = computed(() => (isAssertive.value ? 'assertive' : 'polite'))
+
+const statusIcon = computed(() => snackbarIcons[props.state])
+
+const showActionButton = computed(
+  () => props.showAction && (Boolean(props.actionLabel) || Boolean(slots.action)),
+)
+
+const displayMessage = computed(() => {
+  if (!showActionButton.value) {
+    return props.message
+  }
+
+  if (props.message.length <= SNACKBAR_CHAR_LIMIT_WITH_ACTION) {
+    return props.message
+  }
+
+  return `${props.message.slice(0, SNACKBAR_CHAR_LIMIT_WITH_ACTION)}...`
+})
+
+const showActions = computed(() => showActionButton.value || props.showClose)
+
+const closeAriaLabel = computed(() => t('RcSesSnackbarV2.close', { ns: 'components' }))
+
+const handleClose = () => {
+  if (!props.modelValue) {
+    return
+  }
+
+  isOpen.value = false
+  emit('close')
+}
+
+const handleFocusOut = (event: FocusEvent) => {
+  const root = event.currentTarget
+
+  if (!(root instanceof HTMLElement)) {
+    isPaused.value = false
+    return
+  }
+
+  const next = event.relatedTarget
+
+  if (next instanceof Node && root.contains(next)) {
+    return
+  }
+
+  isPaused.value = false
+}
+
+const handleAction = () => {
+  emit('action')
+
+  if (props.dismissOnAction) {
+    handleClose()
+  }
+}
+
+const handleVisibilityChange = (value: boolean) => {
+  if (!value) {
+    handleClose()
+  }
+}
+</script>

--- a/src/components/common/SnackbarV2/RcSesSnackbarV2.vue
+++ b/src/components/common/SnackbarV2/RcSesSnackbarV2.vue
@@ -1,6 +1,6 @@
 <template>
   <v-snackbar
-    v-model="isOpen"
+    :model-value="props.modelValue"
     class="rc-ses-snackbar-v2-host"
     :timeout="snackbarTimeout"
     location="bottom"
@@ -93,13 +93,6 @@ const isPersisted = computed(
   () => props.persist ?? props.state === SnackbarState.ActionNeeded,
 )
 
-const isOpen = computed({
-  get: () => props.modelValue,
-  set: (value: boolean) => {
-    emit('update:modelValue', value)
-  },
-})
-
 const snackbarTimeout = computed(() => {
   if (isPersisted.value || isPaused.value) {
     return -1
@@ -136,13 +129,17 @@ const showActions = computed(() => showActionButton.value || props.showClose)
 
 const closeAriaLabel = computed(() => t('RcSesSnackbarV2.close', { ns: 'components' }))
 
-const handleClose = () => {
-  if (!props.modelValue) {
+const handleVisibilityChange = (value: boolean) => {
+  if (value || !props.modelValue) {
     return
   }
 
-  isOpen.value = false
+  emit('update:modelValue', false)
   emit('close')
+}
+
+const handleClose = () => {
+  handleVisibilityChange(false)
 }
 
 const handleFocusOut = (event: FocusEvent) => {
@@ -166,12 +163,6 @@ const handleAction = () => {
   emit('action')
 
   if (props.dismissOnAction) {
-    handleClose()
-  }
-}
-
-const handleVisibilityChange = (value: boolean) => {
-  if (!value) {
     handleClose()
   }
 }

--- a/src/components/common/SnackbarV2/config.ts
+++ b/src/components/common/SnackbarV2/config.ts
@@ -1,0 +1,18 @@
+import { SnackbarState } from '@/components/common/SnackbarV2/types'
+
+export const SNACKBAR_DURATION = 10_000
+
+export const SNACKBAR_CHAR_LIMIT_WITH_ACTION = 120
+
+export const snackbarIcons: Record<`${SnackbarState}`, string> = {
+  [SnackbarState.Success]: '$checkCircleFilled',
+  [SnackbarState.Error]: '$xCircleFilled',
+  [SnackbarState.Warning]: '$warningFilled',
+  [SnackbarState.Info]: '$infoFilled',
+  [SnackbarState.ActionNeeded]: '$scroll',
+}
+
+export const assertiveSnackbarStates = new Set<`${SnackbarState}`>([
+  SnackbarState.Error,
+  SnackbarState.ActionNeeded,
+])

--- a/src/components/common/SnackbarV2/defaults.ts
+++ b/src/components/common/SnackbarV2/defaults.ts
@@ -1,0 +1,23 @@
+import { SNACKBAR_DURATION } from './config'
+
+export type SnackbarDefaultsType = {
+  modelValue: boolean
+  showAction: boolean
+  actionLabel: string
+  showClose: boolean
+  duration: number
+  dismissOnAction: boolean
+  contained: boolean
+}
+
+const snackbarV2Defaults = {
+  modelValue: false,
+  showAction: false,
+  actionLabel: '',
+  showClose: true,
+  duration: SNACKBAR_DURATION,
+  dismissOnAction: true,
+  contained: false,
+} satisfies SnackbarDefaultsType
+
+export default snackbarV2Defaults

--- a/src/components/common/SnackbarV2/style.scss
+++ b/src/components/common/SnackbarV2/style.scss
@@ -1,0 +1,146 @@
+@use '/src/styles/vuetify/borders-v2' as borders-v2;
+@use '/src/styles/vuetify/elevation-v2' as elevation-v2;
+@use '/src/styles/vuetify/sizes-v2' as sizes-v2;
+@use '/src/styles/vuetify/spacing-v2' as spacing-v2;
+@use '/src/styles/vuetify/typography-v2' as typography-v2;
+
+.rc-ses-snackbar-v2-host {
+  &:not(.v-snackbar--contained) {
+    margin-bottom: spacing-v2.rc-spacing-v2('spacing-24-v2');
+  }
+
+  .v-snackbar__wrapper {
+    width: auto;
+    min-width: 0;
+    margin-inline: auto;
+    overflow: visible;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  &.v-snackbar--contained {
+    overflow: visible;
+  }
+
+  .v-snackbar__content {
+    width: auto;
+    min-width: 0;
+    padding: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+}
+
+.rc-ses-snackbar-v2 {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: spacing-v2.rc-spacing-v2('spacing-16-v2');
+  width: fit-content;
+  min-width: sizes-v2.rc-size-v2('snackbar-min-width-v2');
+  max-width: sizes-v2.rc-size-v2('snackbar-max-width-v2');
+  min-height: sizes-v2.rc-size-v2('button-height-small-v2');
+  padding: spacing-v2.rc-spacing-v2('snackbar-padding-y-v2')
+    spacing-v2.rc-spacing-v2('spacing-12-v2')
+    spacing-v2.rc-spacing-v2('snackbar-padding-y-v2')
+    spacing-v2.rc-spacing-v2('snackbar-padding-x-v2');
+  background-color: rgb(var(--v-theme-surface-inverse-v2));
+  color: rgb(var(--v-theme-neutral-50-v2));
+  border-radius: borders-v2.rc-radius-v2('radius-8-v2');
+  @include elevation-v2.rc-elevation-v2('elevation-snackbar-v2');
+
+  &--with-action {
+    width: sizes-v2.rc-size-v2('snackbar-max-width-v2');
+    max-width: sizes-v2.rc-size-v2('snackbar-max-width-v2');
+    min-height: sizes-v2.rc-size-v2('button-height-regular-v2');
+
+    .rc-ses-snackbar-v2__state {
+      flex: 1 1 0;
+      min-width: 0;
+    }
+
+    .rc-ses-snackbar-v2__message {
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+  }
+
+  &__state {
+    display: flex;
+    flex: 1 1 auto;
+    align-items: center;
+    gap: spacing-v2.rc-spacing-v2('spacing-8-v2');
+    min-width: 0;
+  }
+
+  &__icon {
+    flex-shrink: 0;
+    @include sizes-v2.rc-icon-size-v2('snackbar-icon-size-v2');
+
+    &--success {
+      color: rgb(var(--v-theme-green-400-v2));
+    }
+
+    &--error {
+      color: rgb(var(--v-theme-red-400-v2));
+    }
+
+    &--warning {
+      color: rgb(var(--v-theme-yellow-400-v2));
+    }
+
+    &--info,
+    &--action-needed {
+      color: rgb(var(--v-theme-cyan-400-v2));
+    }
+  }
+
+  &__message {
+    @include typography-v2.rc-typography-v2('body-small-v2');
+
+    flex: 1 1 auto;
+    margin: 0;
+    min-width: 0;
+  }
+
+  &__actions {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: spacing-v2.rc-spacing-v2('spacing-12-v2');
+  }
+
+  &__action {
+    flex-shrink: 0;
+  }
+
+  &__close {
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    @include sizes-v2.rc-icon-size-v2('icon-large-v2');
+    border: none;
+    background: transparent;
+    color: rgb(var(--v-theme-neutral-50-v2));
+    cursor: pointer;
+    line-height: 0;
+
+    .v-icon {
+      @include sizes-v2.rc-icon-size-v2('icon-medium-v2');
+    }
+
+    &:focus-visible {
+      outline: borders-v2.rc-stroke-v2('border-width-focus-v2') solid
+        rgb(var(--v-theme-border-focus-actual-v2));
+      outline-offset: borders-v2.rc-stroke-v2('stroke-1-v2');
+      border-radius: borders-v2.rc-radius-v2('radius-4-v2');
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rc-ses-snackbar-v2-host .v-snackbar__wrapper {
+    transition: none !important;
+  }
+}

--- a/src/components/common/SnackbarV2/types.ts
+++ b/src/components/common/SnackbarV2/types.ts
@@ -1,0 +1,20 @@
+export enum SnackbarState {
+  Success = 'success',
+  Error = 'error',
+  Warning = 'warning',
+  Info = 'info',
+  ActionNeeded = 'action-needed',
+}
+
+export type SnackbarProps = {
+  state: `${SnackbarState}`
+  message: string
+  modelValue?: boolean
+  showAction?: boolean
+  actionLabel?: string
+  showClose?: boolean
+  duration?: number
+  persist?: boolean
+  dismissOnAction?: boolean
+  contained?: boolean
+}

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -10,6 +10,7 @@ import RcSesCardV2 from '@/components/common/CardV2/RcSesCardV2.vue'
 import RcSesError from '@/components/common/Error/RcSesError.vue'
 import RcSesImageAndTextV2 from '@/components/common/ImageAndTextV2/RcSesImageAndTextV2.vue'
 import RcSesReviewCardV2 from '@/components/common/ReviewCardV2/RcSesReviewCardV2.vue'
+import RcSesSnackbarV2 from '@/components/common/SnackbarV2/RcSesSnackbarV2.vue'
 import RcSesStepperV2 from '@/components/common/StepperV2/RcSesStepperV2.vue'
 import RcSesSubcardV2 from '@/components/common/SubcardV2/RcSesSubcardV2.vue'
 import RcSesButtonV2 from '@/components/common/buttonV2/RcSesButtonV2.vue'
@@ -131,6 +132,7 @@ export function createRcSesComponents(options: object = {}): Plugin<[]> {
 
     app.component('RcSesBadgeV2', RcSesBadgeV2)
     app.component('RcSesImageAndTextV2', RcSesImageAndTextV2)
+    app.component('RcSesSnackbarV2', RcSesSnackbarV2)
     app.component('RcSesStepperV2', RcSesStepperV2)
     app.component('RcSesCardV2', RcSesCardV2)
     app.component('RcSesCardFooterV2', RcSesCardFooterV2)
@@ -157,7 +159,7 @@ export {
 
 export { RcSesAlert, RcSesButton }
 export { RcSesBadgeV2, RcSesButtonV2, RcSesToggleV2 }
-export { RcSesImageAndTextV2, RcSesStepperV2 }
+export { RcSesImageAndTextV2, RcSesSnackbarV2, RcSesStepperV2 }
 export { RcSesModalV2, RcSesBackdropV2 }
 export { RcSesCardV2, RcSesCardFooterV2, RcSesReviewCardV2, RcSesSubcardV2 }
 export { RcSesCheckbox, RcSesCheckboxField }

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -45,6 +45,10 @@ const i18n = () => {
             remove: 'Pašalinti',
           },
 
+          RcSesSnackbarV2: {
+            close: 'Uždaryti',
+          },
+
           RcSesStepperV2: {
             back: 'Grįžti',
             completedStep: 'Užbaigta: {{step}}',
@@ -109,6 +113,10 @@ const i18n = () => {
 
           RcSesBadgeV2: {
             remove: 'Remove',
+          },
+
+          RcSesSnackbarV2: {
+            close: 'Close',
           },
 
           RcSesStepperV2: {

--- a/src/stories/components v2/Snackbar/Snackbar.stories.ts
+++ b/src/stories/components v2/Snackbar/Snackbar.stories.ts
@@ -1,0 +1,134 @@
+import type { Meta, StoryFn } from '@storybook/vue3'
+import { ref } from 'vue'
+
+import RcSesSnackbarV2 from '@/components/common/SnackbarV2/RcSesSnackbarV2.vue'
+import { type SnackbarProps, SnackbarState } from '@/components/common/SnackbarV2/types'
+
+const defaultMessage = 'Short informational text. Replace with context-specific content.'
+const defaultActionLabel = 'Button'
+
+const meta: Meta<typeof RcSesSnackbarV2> = {
+  title: 'componentsV2/Snackbar',
+  component: RcSesSnackbarV2,
+  tags: ['autodocs'],
+  argTypes: {
+    state: {
+      control: 'select',
+      options: [
+        SnackbarState.Success,
+        SnackbarState.Error,
+        SnackbarState.Warning,
+        SnackbarState.Info,
+        SnackbarState.ActionNeeded,
+      ],
+      description: 'Semantic snackbar state',
+    },
+    message: {
+      control: 'text',
+      description: 'Snackbar message text',
+    },
+    showAction: {
+      control: 'boolean',
+      description: 'Toggle the action button',
+    },
+    actionLabel: {
+      control: 'text',
+      description: 'Action button label',
+    },
+    showClose: {
+      control: 'boolean',
+      description: 'Toggle the dismiss close button',
+    },
+    persist: {
+      control: 'boolean',
+      description: 'Disable auto-dismiss',
+    },
+    contained: {
+      control: 'boolean',
+      description: 'Position snackbar within the story container',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryFn<typeof RcSesSnackbarV2>
+
+const snackbarDefaultArgs: Partial<SnackbarProps> = {
+  state: SnackbarState.Success,
+  message: defaultMessage,
+  showAction: false,
+  actionLabel: defaultActionLabel,
+  showClose: true,
+  contained: true,
+  persist: true,
+}
+
+export const Default: Story = (args) => ({
+  components: { RcSesSnackbarV2 },
+  setup() {
+    const open = ref(true)
+
+    return { args, open }
+  },
+  template: `
+    <div class="snackbar-story-frame">
+      <RcSesSnackbarV2 v-bind="args" v-model="open" />
+    </div>
+  `,
+})
+Default.args = snackbarDefaultArgs as Meta<typeof RcSesSnackbarV2>['args']
+
+export const AllStates: Story = () => ({
+  components: { RcSesSnackbarV2 },
+  setup() {
+    const states = [
+      SnackbarState.Success,
+      SnackbarState.Error,
+      SnackbarState.Warning,
+      SnackbarState.Info,
+      SnackbarState.ActionNeeded,
+    ]
+
+    return {
+      states,
+      defaultMessage,
+    }
+  },
+  template: `
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <div v-for="state in states" :key="state" class="snackbar-story-frame">
+        <RcSesSnackbarV2
+          :state="state"
+          :message="defaultMessage"
+          :show-action="false"
+          :model-value="true"
+          contained
+          persist
+        />
+      </div>
+    </div>
+  `,
+})
+
+export const WithAction: Story = () => ({
+  components: { RcSesSnackbarV2 },
+  setup() {
+    const open = ref(true)
+
+    return { open, defaultMessage, defaultActionLabel, SnackbarState }
+  },
+  template: `
+    <div class="snackbar-story-frame">
+      <RcSesSnackbarV2
+        v-model="open"
+        :state="SnackbarState.Info"
+        :message="defaultMessage"
+        show-action
+        :action-label="defaultActionLabel"
+        contained
+        persist
+      />
+    </div>
+  `,
+})

--- a/src/styles/shared/storybook.scss
+++ b/src/styles/shared/storybook.scss
@@ -33,3 +33,17 @@
     }
   }
 }
+
+.snackbar-story-frame {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 96px;
+
+  .rc-ses-snackbar-v2-host.v-snackbar--contained {
+    align-items: center !important;
+    justify-content: center !important;
+  }
+}

--- a/src/styles/vuetify/_elevation-v2.scss
+++ b/src/styles/vuetify/_elevation-v2.scss
@@ -6,6 +6,7 @@ $rc-elevation-v2: (
     0 2px 4px 0 rgba(0, 0, 0, 0.04),
   ),
   'elevation-md-v2': 0 4px 16px 0 rgba(0, 0, 0, 0.08),
+  'elevation-snackbar-v2': 0 4px 16px 0 rgba(0, 0, 0, 0.16),
   'elevation-lg-v2': 0 8px 16px 0 rgba(0, 0, 0, 0.12),
 );
 

--- a/src/styles/vuetify/_sizes-v2.scss
+++ b/src/styles/vuetify/_sizes-v2.scss
@@ -4,6 +4,7 @@ $rc-size-v2-primitives: (
   'size-8-v2': 8px,
   'size-12-v2': 12px,
   'size-16-v2': 16px,
+  'size-18-v2': 18px,
   'size-20-v2': 20px,
   'size-24-v2': 24px,
   'size-32-v2': 32px,
@@ -12,6 +13,8 @@ $rc-size-v2-primitives: (
   'size-44-v2': 44px,
   'size-72-v2': 72px,
   'size-88-v2': 88px,
+  'size-320-v2': 320px,
+  'size-400-v2': 400px,
 );
 
 $rc-size-v2-semantic: (
@@ -31,6 +34,10 @@ $rc-size-v2-semantic: (
   'toggle-track-width-v2': 'size-36-v2',
   'toggle-track-height-v2': 'size-20-v2',
   'toggle-thumb-size-v2': 'size-16-v2',
+  // Snackbar
+  'snackbar-min-width-v2': 'size-320-v2',
+  'snackbar-max-width-v2': 'size-400-v2',
+  'snackbar-icon-size-v2': 'size-18-v2',
 );
 
 @function rc-size-v2($token) {


### PR DESCRIPTION
## 🔗 Task

https://jira.registrucentras.lt/jira/browse/IRM-5291

@tomas562  @saukaite 

## 🧾 Summary

Adds RcSesSnackbarV2 — v2 snackbar with five states (success, error, warning, info, action-needed), optional action button and close button, v-model visibility, 10s auto-dismiss with pause on hover/focus, and accessibility support (role/aria-live per state, i18n close label). Styling uses v2 tokens; animation respects prefers-reduced-motion. Includes SnackbarState enum, Storybook, tests, and library export.

## 📸 Screenshots

<img width="1057" height="803" alt="image" src="https://github.com/user-attachments/assets/985ba622-cbf9-4882-9323-c53277bf853b" />


## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [x] UI matches approved design (Figma)
* [x] Accessibility reviewed (keyboard navigation, labels, semantics)
