### PR TITLE
IRM-5299 (ChipSelectV2)

### DIFF
--- a/src/components/common/ChipSelectV2/RcSesChipSelectV2.test.ts
+++ b/src/components/common/ChipSelectV2/RcSesChipSelectV2.test.ts
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+import RcSesChipSelectV2 from './RcSesChipSelectV2.vue'
+import type { ChipSelectOption, ChipSelectProps } from './types'
+
+const defaultOptions: ChipSelectOption[] = [
+  { text: 'Reikšmė 1', value: 'val1' },
+  { text: 'Reikšmė 2', value: 'val2' },
+  { text: 'Reikšmė 3', value: 'val3' },
+]
+
+const RcSesBadgeV2Stub = {
+  props: ['type', 'showIcon', 'disabled', 'accessibleLabel'],
+  emits: ['click'],
+  template: `
+    <button
+      type="button"
+      :data-type="type"
+      :data-show-icon="showIcon"
+      :disabled="disabled"
+      :aria-label="accessibleLabel"
+      @click="$emit('click')"
+    >
+      <slot />
+    </button>
+  `,
+}
+
+const renderChipSelect = (
+  props: Partial<ChipSelectProps> & { modelValue?: string | number } = {},
+) =>
+  render(RcSesChipSelectV2, {
+    props: {
+      options: defaultOptions,
+      modelValue: 'val1',
+      ...props,
+    },
+    global: {
+      stubs: {
+        RcSesBadgeV2: RcSesBadgeV2Stub,
+      },
+    },
+  })
+
+describe('RcSesChipSelectV2', () => {
+  it('renders all option labels', () => {
+    renderChipSelect()
+
+    expect(
+      screen.getByRole('button', { name: 'Reikšmė 1, selected' }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reikšmė 2' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reikšmė 3' })).toBeInTheDocument()
+  })
+
+  it('applies brand type to the selected option', () => {
+    renderChipSelect({ modelValue: 'val2' })
+
+    expect(screen.getByRole('button', { name: 'Reikšmė 2, selected' })).toHaveAttribute(
+      'data-type',
+      'brand',
+    )
+    expect(screen.getByRole('button', { name: 'Reikšmė 1' })).toHaveAttribute(
+      'data-type',
+      'neutral',
+    )
+  })
+
+  it('updates modelValue when another option is selected', async () => {
+    const { emitted } = renderChipSelect({ modelValue: 'val1' })
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Reikšmė 3' }))
+
+    expect(emitted()['update:modelValue']).toEqual([['val3']])
+  })
+
+  it('does not emit when the already selected option is clicked', async () => {
+    const { emitted } = renderChipSelect({ modelValue: 'val1' })
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Reikšmė 1, selected' }))
+
+    expect(emitted()['update:modelValue']).toBeUndefined()
+  })
+
+  it('does not emit when disabled', async () => {
+    const { emitted } = renderChipSelect({ modelValue: 'val1', disabled: true })
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Reikšmė 2' }))
+
+    expect(emitted()['update:modelValue']).toBeUndefined()
+  })
+
+  it('exposes radiogroup semantics', () => {
+    renderChipSelect({ accessibleLabel: 'Filtras' })
+
+    expect(screen.getByRole('radiogroup', { name: 'Filtras' })).toBeInTheDocument()
+  })
+})

--- a/src/components/common/ChipSelectV2/RcSesChipSelectV2.vue
+++ b/src/components/common/ChipSelectV2/RcSesChipSelectV2.vue
@@ -1,0 +1,57 @@
+<template>
+  <div
+    class="rc-ses-chip-select-v2"
+    role="radiogroup"
+    :aria-label="props.accessibleLabel"
+  >
+    <RcSesBadgeV2
+      v-for="option in props.options"
+      :key="option.value"
+      :type="isSelected(option.value) ? 'brand' : 'neutral'"
+      :show-icon="isSelected(option.value) ? selectedIcon : false"
+      :disabled="props.disabled"
+      :accessible-label="getOptionAccessibleLabel(option)"
+      class="rc-ses-chip-select-v2__item"
+      @click="selectOption(option.value)"
+    >
+      {{ option.text }}
+    </RcSesBadgeV2>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { withDefaults } from 'vue'
+
+import RcSesBadgeV2 from '@/components/common/BadgeV2/RcSesBadgeV2.vue'
+import chipSelectV2Defaults from '@/components/common/ChipSelectV2/defaults'
+import type {
+  ChipSelectOption,
+  ChipSelectProps,
+} from '@/components/common/ChipSelectV2/types'
+
+import './style.scss'
+
+const selectedIcon = 'checkPrimary'
+
+const props = withDefaults(defineProps<ChipSelectProps>(), chipSelectV2Defaults)
+
+const model = defineModel<string | number>()
+
+const isSelected = (value: string | number): boolean => model.value === value
+
+const getOptionAccessibleLabel = (option: ChipSelectOption): string => {
+  if (isSelected(option.value)) {
+    return `${option.text}, selected`
+  }
+
+  return option.text
+}
+
+const selectOption = (value: string | number) => {
+  if (props.disabled || model.value === value) {
+    return
+  }
+
+  model.value = value
+}
+</script>

--- a/src/components/common/ChipSelectV2/defaults.ts
+++ b/src/components/common/ChipSelectV2/defaults.ts
@@ -1,0 +1,13 @@
+import type { ChipSelectOption } from '@/components/common/ChipSelectV2/types'
+
+export type ChipSelectDefaultsType = {
+  options: () => ChipSelectOption[]
+  disabled: boolean
+}
+
+const chipSelectV2Defaults = {
+  options: () => [],
+  disabled: false,
+} satisfies ChipSelectDefaultsType
+
+export default chipSelectV2Defaults

--- a/src/components/common/ChipSelectV2/style.scss
+++ b/src/components/common/ChipSelectV2/style.scss
@@ -1,0 +1,23 @@
+@use '/src/styles/vuetify/spacing-v2' as spacing-v2;
+
+.rc-ses-chip-select-v2 {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: spacing-v2.rc-spacing-v2('spacing-6-v2');
+
+  &__item {
+    cursor: pointer;
+    user-select: none;
+    transition: opacity 0.2s ease, transform 0.1s ease;
+
+    &:active:not(.v-chip--disabled) {
+      transform: scale(0.98);
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rc-ses-chip-select-v2__item {
+    transition: none;
+  }
+}

--- a/src/components/common/ChipSelectV2/types.ts
+++ b/src/components/common/ChipSelectV2/types.ts
@@ -1,0 +1,10 @@
+export type ChipSelectOption = {
+  text: string
+  value: string | number
+}
+
+export type ChipSelectProps = {
+  options: ChipSelectOption[]
+  disabled?: boolean
+  accessibleLabel?: string
+}

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -7,6 +7,7 @@ import RcSesAlert from '@/components/common/Alert/RcSesAlert.vue'
 import RcSesBadgeV2 from '@/components/common/BadgeV2/RcSesBadgeV2.vue'
 import RcSesCardFooterV2 from '@/components/common/CardV2/RcSesCardFooterV2.vue'
 import RcSesCardV2 from '@/components/common/CardV2/RcSesCardV2.vue'
+import RcSesChipSelectV2 from '@/components/common/ChipSelectV2/RcSesChipSelectV2.vue'
 import RcSesError from '@/components/common/Error/RcSesError.vue'
 import RcSesFullPageLoaderV2 from '@/components/common/FullPageLoaderV2/RcSesFullPageLoaderV2.vue'
 import RcSesImageAndTextV2 from '@/components/common/ImageAndTextV2/RcSesImageAndTextV2.vue'
@@ -132,6 +133,7 @@ export function createRcSesComponents(options: object = {}): Plugin<[]> {
     app.component('RcSesTooltip', RcSesTooltip)
 
     app.component('RcSesBadgeV2', RcSesBadgeV2)
+    app.component('RcSesChipSelectV2', RcSesChipSelectV2)
     app.component('RcSesImageAndTextV2', RcSesImageAndTextV2)
     app.component('RcSesLoaderV2', RcSesLoaderV2)
     app.component('RcSesFullPageLoaderV2', RcSesFullPageLoaderV2)
@@ -160,7 +162,7 @@ export {
 }
 
 export { RcSesAlert, RcSesButton }
-export { RcSesBadgeV2, RcSesButtonV2, RcSesToggleV2 }
+export { RcSesBadgeV2, RcSesButtonV2, RcSesChipSelectV2, RcSesToggleV2 }
 export { RcSesImageAndTextV2, RcSesLoaderV2, RcSesFullPageLoaderV2, RcSesStepperV2 }
 export { RcSesModalV2, RcSesBackdropV2 }
 export { RcSesCardV2, RcSesCardFooterV2, RcSesReviewCardV2, RcSesSubcardV2 }

--- a/src/stories/components v2/ChipSelect/ChipSelect.stories.ts
+++ b/src/stories/components v2/ChipSelect/ChipSelect.stories.ts
@@ -1,0 +1,71 @@
+import type { Meta, StoryFn } from '@storybook/vue3'
+import { ref } from 'vue'
+
+import RcSesChipSelectV2 from '@/components/common/ChipSelectV2/RcSesChipSelectV2.vue'
+import type { ChipSelectProps } from '@/components/common/ChipSelectV2/types'
+
+const defaultOptions: ChipSelectProps['options'] = [
+  { text: 'Reikšmė 1', value: 'val1' },
+  { text: 'Reikšmė 2', value: 'val2' },
+  { text: 'Reikšmė 3', value: 'val3' },
+]
+
+const meta: Meta<typeof RcSesChipSelectV2> = {
+  title: 'componentsV2/ChipSelect',
+  component: RcSesChipSelectV2,
+  tags: ['autodocs'],
+  argTypes: {
+    options: {
+      control: 'object',
+      description: 'Selectable chip options',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Disable all chips',
+    },
+    accessibleLabel: {
+      control: 'text',
+      description: 'Accessible name for the chip group',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryFn<typeof RcSesChipSelectV2>
+
+const chipSelectDefaultArgs: Partial<ChipSelectProps> = {
+  options: defaultOptions,
+  disabled: false,
+  accessibleLabel: 'Pasirinkite reikšmę',
+}
+
+export const Default: Story = (args) => ({
+  components: { RcSesChipSelectV2 },
+  setup() {
+    const value = ref('val1')
+
+    return { args, value }
+  },
+  template: `
+    <RcSesChipSelectV2 v-bind="args" v-model="value" />
+  `,
+})
+Default.args = chipSelectDefaultArgs as Meta<typeof RcSesChipSelectV2>['args']
+
+export const Disabled: Story = () => ({
+  components: { RcSesChipSelectV2 },
+  setup() {
+    const value = ref('val2')
+
+    return { value, options: defaultOptions }
+  },
+  template: `
+    <RcSesChipSelectV2
+      v-model="value"
+      :options="options"
+      disabled
+      accessible-label="Pasirinkite reikšmę"
+    />
+  `,
+})


### PR DESCRIPTION
## 🔗 Task

https://jira.registrucentras.lt/jira/browse/IRM-5299

@tomas562  @saukaite 

## 🧾 Summary

Adds RcSesChipSelectV2 — v2 single-select chip group built on RcSesBadgeV2, with options (text / value), v-model selection, optional disabled state, and accessibility support (role="radiogroup", group accessibleLabel, per-chip labels with selected state). Selected chips use brand styling with a check icon; unselected use neutral. Styling uses v2 spacing tokens; animation respects prefers-reduced-motion. Includes Storybook, tests, and library export.

## 📸 Screenshots

<img width="1056" height="216" alt="image" src="https://github.com/user-attachments/assets/fd540b03-5196-4377-bd71-2902bcb28d63" />


## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [x] UI matches approved design (Figma)
* [x] Accessibility reviewed (keyboard navigation, labels, semantics)
