### PR TITLE
IRM-5284 (CheckboxV2, CheckboxSelectableAreaV2)

### DIFF
--- a/src/components/common/inputs/Checkboxes/CheckboxSelectableAreaV2/RcSesCheckboxSelectableAreaV2.test.ts
+++ b/src/components/common/inputs/Checkboxes/CheckboxSelectableAreaV2/RcSesCheckboxSelectableAreaV2.test.ts
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen } from '@testing-library/vue'
+import I18NextVue from 'i18next-vue'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+
+import initI18n from '@/plugins/i18n'
+
+import RcSesCheckboxSelectableAreaV2 from './RcSesCheckboxSelectableAreaV2.vue'
+import type { CheckboxSelectableAreaProps } from './types'
+
+const { i18next } = initI18n()
+
+const VCheckboxStub = defineComponent({
+  name: 'VCheckbox',
+  inheritAttrs: false,
+  props: {
+    modelValue: { type: Boolean, default: false },
+    disabled: { type: Boolean, default: false },
+    indeterminate: { type: Boolean, default: false },
+  },
+  emits: ['update:modelValue', 'click'],
+  setup(checkboxProps, { emit, attrs }) {
+    return () =>
+      h('div', { class: ['v-checkbox', 'rc-ses-checkbox-v2', attrs.class] }, [
+        h('input', {
+          type: 'checkbox',
+          role: 'checkbox',
+          'aria-label': attrs['aria-label'],
+          disabled: checkboxProps.disabled,
+          checked: checkboxProps.modelValue === true,
+          onChange: (event: Event) => {
+            if (checkboxProps.disabled) {
+              return
+            }
+
+            emit('update:modelValue', (event.target as HTMLInputElement).checked)
+          },
+          onClick: (event: Event) => {
+            event.stopPropagation()
+            emit('click')
+          },
+        }),
+      ])
+  },
+})
+
+const renderSelectableArea = (
+  props: Partial<CheckboxSelectableAreaProps> & { modelValue?: boolean } = {},
+) =>
+  render(RcSesCheckboxSelectableAreaV2, {
+    props: {
+      description: 'Description text',
+      modelValue: false,
+      ...props,
+    },
+    global: {
+      plugins: [[I18NextVue, { i18next }]],
+      stubs: {
+        VCheckbox: VCheckboxStub,
+      },
+    },
+  })
+
+describe('RcSesCheckboxSelectableAreaV2', () => {
+  it('renders description text', () => {
+    renderSelectableArea()
+
+    expect(screen.getByText('Description text')).toBeInTheDocument()
+  })
+
+  it('renders title when provided', () => {
+    const { container } = renderSelectableArea({ title: 'Title' })
+
+    expect(screen.getByText('Title')).toBeInTheDocument()
+    expect(container.querySelector('.rc-ses-checkbox-selectable-area-v2')).toHaveClass(
+      'rc-ses-checkbox-selectable-area-v2--with-heading',
+    )
+  })
+
+  it('renders trailing value when provided', () => {
+    renderSelectableArea({ trailing: '00,00 €' })
+
+    expect(screen.getByText('00,00 €')).toBeInTheDocument()
+  })
+
+  it('toggles modelValue when the area is clicked', async () => {
+    const { emitted } = renderSelectableArea({ modelValue: false })
+
+    await fireEvent.click(screen.getByText('Description text'))
+
+    expect(emitted()['update:modelValue']).toEqual([[true]])
+  })
+
+  it('applies checked modifier when selected', () => {
+    const { container } = renderSelectableArea({ modelValue: true })
+
+    expect(container.querySelector('.rc-ses-checkbox-selectable-area-v2')).toHaveClass(
+      'rc-ses-checkbox-selectable-area-v2--checked',
+    )
+  })
+
+  it('does not toggle when disabled', async () => {
+    const { emitted } = renderSelectableArea({ disabled: true })
+
+    await fireEvent.click(screen.getByText('Description text'))
+
+    expect(emitted()['update:modelValue']).toBeUndefined()
+  })
+
+  it('renders loading skeleton', () => {
+    const { container } = renderSelectableArea({ loading: true })
+
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    expect(
+      container.querySelector('.rc-ses-checkbox-selectable-area-v2--loading'),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/common/inputs/Checkboxes/CheckboxSelectableAreaV2/RcSesCheckboxSelectableAreaV2.vue
+++ b/src/components/common/inputs/Checkboxes/CheckboxSelectableAreaV2/RcSesCheckboxSelectableAreaV2.vue
@@ -1,0 +1,121 @@
+<template>
+  <div
+    v-if="props.loading"
+    :class="[
+      'rc-ses-checkbox-selectable-area-v2',
+      'rc-ses-checkbox-selectable-area-v2--loading',
+      { 'rc-ses-checkbox-selectable-area-v2--with-heading': hasHeading },
+    ]"
+    role="status"
+    :aria-label="loadingAriaLabel"
+  >
+    <RcSesCheckboxV2 class="rc-ses-checkbox-selectable-area-v2__checkbox" loading />
+    <div class="rc-ses-checkbox-selectable-area-v2__content">
+      <span
+        v-if="hasHeading"
+        class="rc-ses-checkbox-selectable-area-v2__skeleton-line rc-ses-checkbox-selectable-area-v2__skeleton-line--title"
+      />
+      <span
+        class="rc-ses-checkbox-selectable-area-v2__skeleton-line rc-ses-checkbox-selectable-area-v2__skeleton-line--description"
+      />
+    </div>
+    <span
+      v-if="props.trailing"
+      class="rc-ses-checkbox-selectable-area-v2__skeleton-line rc-ses-checkbox-selectable-area-v2__skeleton-line--trailing"
+    />
+  </div>
+
+  <div
+    v-else
+    :class="[
+      'rc-ses-checkbox-selectable-area-v2',
+      {
+        'rc-ses-checkbox-selectable-area-v2--checked': model && !props.indeterminate,
+        'rc-ses-checkbox-selectable-area-v2--disabled': props.disabled,
+        'rc-ses-checkbox-selectable-area-v2--error': hasError,
+        'rc-ses-checkbox-selectable-area-v2--with-heading': hasHeading,
+      },
+    ]"
+    role="button"
+    tabindex="0"
+    :aria-disabled="props.disabled || undefined"
+    :aria-pressed="model"
+    :aria-label="checkboxAccessibleLabel"
+    @click="handleAreaClick"
+    @keydown.enter.prevent="handleAreaClick"
+    @keydown.space.prevent="handleAreaClick"
+  >
+    <RcSesCheckboxV2
+      v-model="model"
+      class="rc-ses-checkbox-selectable-area-v2__checkbox"
+      :show-label="false"
+      :disabled="props.disabled"
+      :indeterminate="props.indeterminate"
+      :error="hasError"
+      :accessible-label="checkboxAccessibleLabel"
+      @click.stop
+    />
+
+    <div class="rc-ses-checkbox-selectable-area-v2__content">
+      <p v-if="hasHeading" class="rc-ses-checkbox-selectable-area-v2__title">
+        <slot name="title">{{ props.title }}</slot>
+      </p>
+      <p class="rc-ses-checkbox-selectable-area-v2__description">
+        <slot>{{ props.description }}</slot>
+      </p>
+    </div>
+
+    <span v-if="props.trailing" class="rc-ses-checkbox-selectable-area-v2__trailing">
+      <slot name="trailing">{{ props.trailing }}</slot>
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useTranslation } from 'i18next-vue'
+import { computed } from 'vue'
+
+import checkboxSelectableAreaV2Defaults from '@/components/common/inputs/Checkboxes/CheckboxSelectableAreaV2/defaults'
+import type { CheckboxSelectableAreaProps } from '@/components/common/inputs/Checkboxes/CheckboxSelectableAreaV2/types'
+import RcSesCheckboxV2 from '@/components/common/inputs/Checkboxes/CheckboxV2/RcSesCheckboxV2.vue'
+
+import './style.scss'
+
+const props = withDefaults(
+  defineProps<CheckboxSelectableAreaProps>(),
+  checkboxSelectableAreaV2Defaults,
+)
+
+const model = defineModel<boolean>({ default: false })
+
+const { t } = useTranslation()
+
+const hasHeading = computed(() => Boolean(props.title))
+
+const hasError = computed(() => Boolean(props.error))
+
+const checkboxAccessibleLabel = computed(
+  () => props.accessibleLabel ?? props.title ?? props.description,
+)
+
+const loadingAriaLabel = computed(
+  () =>
+    props.accessibleLabel ??
+    props.title ??
+    props.description ??
+    t('RcSesCheckboxV2.loading', { ns: 'components' }),
+)
+
+const handleAreaClick = () => {
+  if (props.disabled) {
+    return
+  }
+
+  if (props.indeterminate) {
+    model.value = true
+    return
+  }
+
+  model.value = !model.value
+}
+</script>

--- a/src/components/common/inputs/Checkboxes/CheckboxSelectableAreaV2/defaults.ts
+++ b/src/components/common/inputs/Checkboxes/CheckboxSelectableAreaV2/defaults.ts
@@ -1,0 +1,15 @@
+export type CheckboxSelectableAreaDefaultsType = {
+  disabled: boolean
+  indeterminate: boolean
+  loading: boolean
+  error: boolean
+}
+
+const checkboxSelectableAreaV2Defaults = {
+  disabled: false,
+  indeterminate: false,
+  loading: false,
+  error: false,
+} satisfies CheckboxSelectableAreaDefaultsType
+
+export default checkboxSelectableAreaV2Defaults

--- a/src/components/common/inputs/Checkboxes/CheckboxSelectableAreaV2/style.scss
+++ b/src/components/common/inputs/Checkboxes/CheckboxSelectableAreaV2/style.scss
@@ -1,0 +1,215 @@
+@use '/src/styles/vuetify/borders-v2' as borders-v2;
+@use '/src/styles/vuetify/sizes-v2' as sizes-v2;
+@use '/src/styles/vuetify/spacing-v2' as spacing-v2;
+@use '/src/styles/vuetify/typography-v2' as typography-v2;
+
+.rc-ses-checkbox-selectable-area-v2 {
+  box-sizing: border-box;
+  display: flex;
+  align-items: flex-start;
+  gap: spacing-v2.rc-spacing-v2('spacing-8-v2');
+  width: 100%;
+  padding: spacing-v2.rc-spacing-v2('spacing-8-v2')
+    spacing-v2.rc-spacing-v2('spacing-12-v2');
+  border: borders-v2.rc-stroke-v2('stroke-2-v2') solid transparent;
+  border-radius: borders-v2.rc-radius-v2('radius-6-v2');
+  background-color: rgb(var(--v-theme-surface-base-v2));
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+
+  &__checkbox {
+    flex-shrink: 0;
+
+    &.rc-ses-checkbox-v2.v-checkbox {
+      .v-selection-control {
+        min-height: sizes-v2.rc-size-v2('size-24-v2') !important;
+        padding-block: 0;
+      }
+
+      .v-input__details {
+        display: none;
+      }
+    }
+
+    &.rc-ses-checkbox-v2--loading {
+      padding-block: 0;
+    }
+  }
+
+  &__content {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    justify-content: flex-start;
+    gap: spacing-v2.rc-spacing-v2('spacing-2-v2');
+    min-width: 0;
+  }
+
+  &__title {
+    @include typography-v2.rc-typography-v2('body-large-v2');
+
+    margin: 0;
+    color: rgb(var(--v-theme-text-default-v2));
+  }
+
+  &__description {
+    @include typography-v2.rc-typography-v2('body-large-v2');
+
+    margin: 0;
+    color: rgb(var(--v-theme-neutral-800-v2));
+  }
+
+  &--with-heading &__description {
+    @include typography-v2.rc-typography-v2('body-small-v2');
+  }
+
+  &__trailing {
+    @include typography-v2.rc-typography-v2('body-large-v2');
+
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: flex-end;
+    gap: spacing-v2.rc-spacing-v2('spacing-4-v2');
+    margin-inline-start: auto;
+    color: rgb(var(--v-theme-text-default-v2));
+    text-align: right;
+    white-space: nowrap;
+  }
+
+  &__skeleton-line {
+    display: block;
+    border-radius: borders-v2.rc-radius-v2('radius-4-v2');
+    background: linear-gradient(
+        90deg,
+        rgba(var(--v-theme-neutral-200-v2), 0) 0%,
+        rgb(var(--v-theme-neutral-200-v2)) 70.19%,
+        rgba(var(--v-theme-neutral-200-v2), 0) 100%
+      ),
+      rgb(var(--v-theme-neutral-100-v2));
+    background-size: 200% 100%;
+    animation: rc-ses-checkbox-selectable-area-v2-skeleton 1.4s ease infinite;
+
+    &--title {
+      width: 200px;
+      height: sizes-v2.rc-size-v2('size-20-v2');
+      margin-block: spacing-v2.rc-spacing-v2('spacing-2-v2');
+    }
+
+    &--description {
+      width: 100%;
+      max-width: 320px;
+      height: sizes-v2.rc-size-v2('size-16-v2');
+      margin-block: spacing-v2.rc-spacing-v2('spacing-2-v2');
+    }
+
+    &--trailing {
+      flex-grow: 1;
+      width: 56px;
+      height: sizes-v2.rc-size-v2('size-16-v2');
+      margin-block: spacing-v2.rc-spacing-v2('spacing-4-v2');
+    }
+  }
+
+  &:hover:not(.rc-ses-checkbox-selectable-area-v2--disabled):not(
+      .rc-ses-checkbox-selectable-area-v2--loading
+    ):not(.rc-ses-checkbox-selectable-area-v2--checked):not(
+      .rc-ses-checkbox-selectable-area-v2--error
+    ):not(:focus-visible) {
+    background-color: rgb(var(--v-theme-neutral-100-v2));
+
+    .rc-ses-checkbox-v2 .v-selection-control__input {
+      border-color: rgb(var(--v-theme-cyan-500-v2));
+      box-shadow: 0 0 0 #{borders-v2.rc-stroke-v2('stroke-4-v2')} rgba(var(--v-theme-cyan-400-v2), 0.2);
+    }
+  }
+
+  &:focus-visible:not(.rc-ses-checkbox-selectable-area-v2--disabled):not(
+      .rc-ses-checkbox-selectable-area-v2--loading
+    ) {
+    border-color: rgb(var(--v-theme-border-focus-actual-v2));
+    outline: none;
+
+    .rc-ses-checkbox-v2 .v-selection-control__input {
+      box-shadow: none;
+
+      &::after {
+        content: '';
+        position: absolute;
+        inset: calc(#{borders-v2.rc-stroke-v2('stroke-4-v2')} * -1);
+        box-sizing: border-box;
+        border: borders-v2.rc-stroke-v2('border-width-focus-v2') solid
+          rgb(var(--v-theme-border-focus-actual-v2));
+        border-radius: borders-v2.rc-radius-v2('radius-8-v2');
+        pointer-events: none;
+      }
+    }
+  }
+
+  &--checked {
+    border-color: rgb(var(--v-theme-cyan-500-v2));
+    background-color: rgb(var(--v-theme-cyan-50-v2));
+  }
+
+  &--error {
+    border-color: rgb(var(--v-theme-red-600-v2));
+
+    &:hover:not(.rc-ses-checkbox-selectable-area-v2--disabled):not(:focus-visible) {
+      background-color: rgb(var(--v-theme-red-50-v2));
+
+      .rc-ses-checkbox-v2 .v-selection-control__input {
+        border-color: rgb(var(--v-theme-red-500-v2));
+        box-shadow: 0 0 0 #{borders-v2.rc-stroke-v2('stroke-4-v2')} rgba(var(--v-theme-red-600-v2), 0.2);
+      }
+    }
+  }
+
+  &--disabled {
+    cursor: not-allowed;
+
+    .rc-ses-checkbox-selectable-area-v2__title,
+    .rc-ses-checkbox-selectable-area-v2__description,
+    .rc-ses-checkbox-selectable-area-v2__trailing {
+      color: rgb(var(--v-theme-text-secondary-v2));
+    }
+  }
+
+  &--loading {
+    cursor: default;
+    pointer-events: none;
+  }
+
+  &--with-heading {
+    align-items: flex-start;
+  }
+
+  &:not(.rc-ses-checkbox-selectable-area-v2--with-heading) {
+    align-items: center;
+
+    .rc-ses-checkbox-selectable-area-v2__trailing {
+      align-self: center;
+    }
+  }
+}
+
+@keyframes rc-ses-checkbox-selectable-area-v2-skeleton {
+  0% {
+    background-position: 100% 0;
+  }
+
+  100% {
+    background-position: -100% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rc-ses-checkbox-selectable-area-v2 {
+    transition: none;
+  }
+
+  .rc-ses-checkbox-selectable-area-v2__skeleton-line {
+    animation: none;
+  }
+}

--- a/src/components/common/inputs/Checkboxes/CheckboxSelectableAreaV2/types.ts
+++ b/src/components/common/inputs/Checkboxes/CheckboxSelectableAreaV2/types.ts
@@ -1,0 +1,10 @@
+export type CheckboxSelectableAreaProps = {
+  title?: string
+  description: string
+  trailing?: string
+  disabled?: boolean
+  indeterminate?: boolean
+  loading?: boolean
+  error?: boolean | string
+  accessibleLabel?: string
+}

--- a/src/components/common/inputs/Checkboxes/CheckboxV2/RcSesCheckboxV2.test.ts
+++ b/src/components/common/inputs/Checkboxes/CheckboxV2/RcSesCheckboxV2.test.ts
@@ -1,0 +1,157 @@
+import { fireEvent, render, screen } from '@testing-library/vue'
+import I18NextVue from 'i18next-vue'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+
+import initI18n from '@/plugins/i18n'
+
+import RcSesCheckboxV2 from './RcSesCheckboxV2.vue'
+import type { CheckboxProps } from './types'
+
+const { i18next } = initI18n()
+
+const VCheckboxStub = defineComponent({
+  name: 'VCheckbox',
+  inheritAttrs: false,
+  props: {
+    modelValue: { type: Boolean, default: false },
+    label: { type: String, default: undefined },
+    disabled: { type: Boolean, default: false },
+    indeterminate: { type: Boolean, default: false },
+    error: { type: Boolean, default: false },
+    errorMessages: { type: [String, Array], default: undefined },
+    hideDetails: { type: [Boolean, String], default: false },
+    trueIcon: { type: String, default: undefined },
+    falseIcon: { type: String, default: undefined },
+    indeterminateIcon: { type: String, default: undefined },
+  },
+  emits: ['update:modelValue', 'click'],
+  setup(checkboxProps, { emit, attrs, slots }) {
+    const inputId = 'rc-checkbox-stub-input'
+
+    return () =>
+      h(
+        'div',
+        {
+          class: [
+            'v-checkbox',
+            'rc-ses-checkbox-v2',
+            attrs.class,
+            {
+              'rc-ses-checkbox-v2--checked':
+                checkboxProps.modelValue && !checkboxProps.indeterminate,
+              'rc-ses-checkbox-v2--indeterminate': checkboxProps.indeterminate,
+              'rc-ses-checkbox-v2--disabled': checkboxProps.disabled,
+              'rc-ses-checkbox-v2--error': checkboxProps.error,
+            },
+          ],
+        },
+        [
+          h('input', {
+            id: inputId,
+            type: 'checkbox',
+            role: 'checkbox',
+            'aria-label': attrs['aria-label'],
+            'aria-invalid': checkboxProps.error ? 'true' : undefined,
+            disabled: checkboxProps.disabled,
+            checked: checkboxProps.modelValue === true,
+            indeterminate: checkboxProps.indeterminate,
+            onChange: (event: Event) => {
+              if (checkboxProps.disabled) {
+                return
+              }
+
+              emit('update:modelValue', (event.target as HTMLInputElement).checked)
+            },
+            onClick: () => emit('click'),
+          }),
+          checkboxProps.indeterminate
+            ? h('span', { 'data-icon': checkboxProps.indeterminateIcon })
+            : null,
+          checkboxProps.label
+            ? h('label', { for: inputId }, checkboxProps.label)
+            : slots.label?.(),
+          checkboxProps.errorMessages
+            ? h('p', {}, String(checkboxProps.errorMessages))
+            : null,
+        ],
+      )
+  },
+})
+
+const renderCheckbox = (props: Partial<CheckboxProps> & { modelValue?: boolean } = {}) =>
+  render(RcSesCheckboxV2, {
+    props: {
+      label: 'Checkbox text',
+      modelValue: false,
+      ...props,
+    },
+    global: {
+      plugins: [[I18NextVue, { i18next }]],
+      stubs: {
+        VCheckbox: VCheckboxStub,
+      },
+    },
+  })
+
+describe('RcSesCheckboxV2', () => {
+  it('renders the label text', () => {
+    renderCheckbox()
+
+    expect(screen.getByText('Checkbox text')).toBeInTheDocument()
+  })
+
+  it('toggles modelValue on click', async () => {
+    const { emitted } = renderCheckbox({ modelValue: false })
+
+    await fireEvent.click(screen.getByRole('checkbox'))
+
+    expect(emitted()['update:modelValue']).toEqual([[true]])
+  })
+
+  it('applies checked modifier when selected', () => {
+    const { container } = renderCheckbox({ modelValue: true })
+
+    expect(container.querySelector('.rc-ses-checkbox-v2')).toHaveClass(
+      'rc-ses-checkbox-v2--checked',
+    )
+  })
+
+  it('applies indeterminate modifier and icon', () => {
+    const { container } = renderCheckbox({ indeterminate: true, modelValue: false })
+
+    expect(container.querySelector('.rc-ses-checkbox-v2')).toHaveClass(
+      'rc-ses-checkbox-v2--indeterminate',
+    )
+    expect(container.querySelector('[data-icon="$minusBold"]')).toBeInTheDocument()
+  })
+
+  it('does not toggle when disabled', async () => {
+    const { emitted } = renderCheckbox({ disabled: true, modelValue: false })
+
+    await fireEvent.click(screen.getByRole('checkbox'))
+
+    expect(emitted()['update:modelValue']).toBeUndefined()
+  })
+
+  it('shows error message and aria-invalid when error is a string', () => {
+    renderCheckbox({ error: 'Privalomas laukas' })
+
+    expect(screen.getByText('Privalomas laukas')).toBeInTheDocument()
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('renders loading skeleton instead of the control', () => {
+    const { container } = renderCheckbox({ loading: true })
+
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    expect(container.querySelector('.rc-ses-checkbox-v2--loading')).toBeInTheDocument()
+  })
+
+  it('hides the label when showLabel is false', () => {
+    renderCheckbox({ showLabel: false, accessibleLabel: 'Pasirinkti' })
+
+    expect(screen.queryByText('Checkbox text')).not.toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: 'Pasirinkti' })).toBeInTheDocument()
+  })
+})

--- a/src/components/common/inputs/Checkboxes/CheckboxV2/RcSesCheckboxV2.vue
+++ b/src/components/common/inputs/Checkboxes/CheckboxV2/RcSesCheckboxV2.vue
@@ -1,0 +1,95 @@
+<template>
+  <div
+    v-if="props.loading"
+    class="rc-ses-checkbox-v2 rc-ses-checkbox-v2--loading"
+    role="status"
+    :aria-label="loadingAriaLabel"
+  >
+    <span class="rc-ses-checkbox-v2__skeleton-control" aria-hidden="true" />
+    <span
+      v-if="props.showLabel && props.label"
+      class="rc-ses-checkbox-v2__skeleton-label"
+      aria-hidden="true"
+    />
+  </div>
+
+  <v-checkbox
+    v-else
+    v-model="model"
+    :class="[
+      'rc-ses-checkbox-v2',
+      {
+        'rc-ses-checkbox-v2--checked': model && !props.indeterminate,
+        'rc-ses-checkbox-v2--indeterminate': props.indeterminate,
+        'rc-ses-checkbox-v2--disabled': props.disabled,
+        'rc-ses-checkbox-v2--error': hasError,
+      },
+    ]"
+    :label="displayLabel"
+    :aria-label="ariaLabelValue"
+    :disabled="props.disabled"
+    :indeterminate="props.indeterminate"
+    :error="hasError"
+    :error-messages="errorMessage"
+    :hide-details="!errorMessage"
+    :true-icon="trueIcon"
+    :false-icon="falseIcon"
+    :indeterminate-icon="indeterminateIcon"
+    density="compact"
+    :ripple="false"
+    @click="handleClick"
+  >
+    <template v-if="$slots.default" #label>
+      <slot />
+    </template>
+  </v-checkbox>
+</template>
+
+<script setup lang="ts">
+import { useTranslation } from 'i18next-vue'
+import { computed } from 'vue'
+
+import checkboxV2Defaults from '@/components/common/inputs/Checkboxes/CheckboxV2/defaults'
+import type { CheckboxProps } from '@/components/common/inputs/Checkboxes/CheckboxV2/types'
+
+import './style.scss'
+
+const props = withDefaults(defineProps<CheckboxProps>(), checkboxV2Defaults)
+
+const model = defineModel<boolean>({ default: false })
+
+const { t } = useTranslation()
+
+const trueIcon = '$checkBold'
+const falseIcon = '$checkboxOff'
+const indeterminateIcon = '$minusBold'
+
+const hasError = computed(() => Boolean(props.error))
+
+const errorMessage = computed(() =>
+  typeof props.error === 'string' ? props.error : undefined,
+)
+
+const displayLabel = computed(() => (props.showLabel ? props.label : undefined))
+
+const ariaLabelValue = computed(() => {
+  if (props.showLabel && props.label) {
+    return undefined
+  }
+
+  return props.accessibleLabel ?? props.label
+})
+
+const loadingAriaLabel = computed(
+  () =>
+    props.accessibleLabel ??
+    props.label ??
+    t('RcSesCheckboxV2.loading', { ns: 'components' }),
+)
+
+const handleClick = () => {
+  if (props.indeterminate && !props.disabled) {
+    model.value = true
+  }
+}
+</script>

--- a/src/components/common/inputs/Checkboxes/CheckboxV2/defaults.ts
+++ b/src/components/common/inputs/Checkboxes/CheckboxV2/defaults.ts
@@ -1,0 +1,17 @@
+export type CheckboxDefaultsType = {
+  showLabel: boolean
+  disabled: boolean
+  indeterminate: boolean
+  loading: boolean
+  error: boolean
+}
+
+const checkboxV2Defaults = {
+  showLabel: true,
+  disabled: false,
+  indeterminate: false,
+  loading: false,
+  error: false,
+} satisfies CheckboxDefaultsType
+
+export default checkboxV2Defaults

--- a/src/components/common/inputs/Checkboxes/CheckboxV2/style.scss
+++ b/src/components/common/inputs/Checkboxes/CheckboxV2/style.scss
@@ -1,0 +1,247 @@
+@use '/src/styles/vuetify/borders-v2' as borders-v2;
+@use '/src/styles/vuetify/sizes-v2' as sizes-v2;
+@use '/src/styles/vuetify/spacing-v2' as spacing-v2;
+@use '/src/styles/vuetify/typography-v2' as typography-v2;
+
+.rc-ses-checkbox-v2 {
+  $checkbox-size: sizes-v2.rc-size-v2('checkbox-size-v2');
+  $checkbox-container-size: sizes-v2.rc-size-v2('size-24-v2');
+  $hover-ring: 0 0 0 #{borders-v2.rc-stroke-v2('stroke-4-v2')} rgba(var(--v-theme-cyan-400-v2), 0.2);
+  $error-hover-ring: 0 0 0 #{borders-v2.rc-stroke-v2('stroke-4-v2')} rgba(var(--v-theme-red-600-v2), 0.2);
+
+  &.v-checkbox {
+    flex: 0 0 auto;
+
+    .v-input__control {
+      align-items: flex-start;
+    }
+
+    .v-selection-control {
+      min-height: $checkbox-container-size !important;
+      align-items: flex-start;
+      gap: 0;
+      padding-block: spacing-v2.rc-spacing-v2('spacing-8-v2');
+    }
+
+    .v-selection-control__wrapper {
+      box-sizing: border-box;
+      display: flex;
+      flex: none;
+      align-items: center;
+      justify-content: center;
+      width: $checkbox-container-size;
+      height: $checkbox-container-size;
+      margin: 0;
+      padding: spacing-v2.rc-spacing-v2('spacing-2-v2');
+    }
+
+    .v-selection-control__input {
+      position: relative;
+      box-sizing: border-box;
+      width: $checkbox-size;
+      height: $checkbox-size;
+      border: borders-v2.rc-stroke-v2('stroke-2-v2') solid
+        rgb(var(--v-theme-neutral-500-v2));
+      border-radius: borders-v2.rc-radius-v2('radius-4-v2');
+      background-color: rgb(var(--v-theme-surface-base-v2));
+      transition:
+        background-color 0.15s ease,
+        border-color 0.15s ease,
+        box-shadow 0.15s ease;
+
+      &::before {
+        opacity: 0 !important;
+      }
+
+      .v-icon {
+        @include sizes-v2.rc-icon-size-v2('checkbox-icon-size-v2');
+
+        color: transparent;
+        opacity: 0;
+        transition:
+          color 0.15s ease,
+          opacity 0.15s ease;
+      }
+    }
+
+    .v-label {
+      @include typography-v2.rc-typography-v2('body-large-v2');
+
+      opacity: 1;
+      padding-inline-start: spacing-v2.rc-spacing-v2('spacing-8-v2');
+      color: rgb(var(--v-theme-text-default-v2));
+    }
+
+    .v-messages {
+      @include typography-v2.rc-typography-v2('body-caption-v2');
+
+      padding-inline-start: calc(
+        #{$checkbox-container-size} + #{spacing-v2.rc-spacing-v2('spacing-8-v2')}
+      );
+      color: rgb(var(--v-theme-error-border-v2));
+      opacity: 1;
+    }
+
+    .v-input__details {
+      padding-inline: 0;
+      min-height: auto;
+      padding-block-start: spacing-v2.rc-spacing-v2('spacing-4-v2');
+    }
+
+    &.rc-ses-checkbox-v2--checked .v-selection-control__input,
+    &.rc-ses-checkbox-v2--indeterminate .v-selection-control__input {
+      border-width: borders-v2.rc-stroke-v2('stroke-1-v2');
+      border-color: rgb(var(--v-theme-cyan-500-v2));
+      background-color: rgb(var(--v-theme-cyan-500-v2));
+
+      .v-icon {
+        color: rgb(var(--v-theme-text-inverse-v2));
+        opacity: 1;
+      }
+    }
+
+    &:hover:not(.v-input--disabled):not(.rc-ses-checkbox-v2--error)
+      .v-selection-control:not(.v-selection-control--focus-visible)
+      .v-selection-control__input {
+      border-color: rgb(var(--v-theme-cyan-500-v2));
+      box-shadow: $hover-ring;
+    }
+
+    .v-selection-control--focus-visible .v-selection-control__input {
+      box-shadow: none;
+
+      &::after {
+        content: '';
+        position: absolute;
+        inset: calc(#{borders-v2.rc-stroke-v2('stroke-4-v2')} * -1);
+        box-sizing: border-box;
+        border: borders-v2.rc-stroke-v2('border-width-focus-v2') solid
+          rgb(var(--v-theme-border-focus-actual-v2));
+        border-radius: borders-v2.rc-radius-v2('radius-8-v2');
+        pointer-events: none;
+      }
+    }
+
+    &.rc-ses-checkbox-v2--error {
+      .v-selection-control__input {
+        border-color: rgb(var(--v-theme-red-500-v2));
+      }
+
+      &.rc-ses-checkbox-v2--checked .v-selection-control__input,
+      &.rc-ses-checkbox-v2--indeterminate .v-selection-control__input {
+        border-color: rgb(var(--v-theme-red-500-v2));
+        background-color: rgb(var(--v-theme-red-500-v2));
+      }
+
+      &:hover:not(.v-input--disabled)
+        .v-selection-control:not(.v-selection-control--focus-visible)
+        .v-selection-control__input {
+        border-color: rgb(var(--v-theme-red-500-v2));
+        box-shadow: $error-hover-ring;
+      }
+
+      &:hover:not(.v-input--disabled).rc-ses-checkbox-v2--checked
+        .v-selection-control:not(.v-selection-control--focus-visible)
+        .v-selection-control__input,
+      &:hover:not(.v-input--disabled).rc-ses-checkbox-v2--indeterminate
+        .v-selection-control:not(.v-selection-control--focus-visible)
+        .v-selection-control__input {
+        border-width: borders-v2.rc-stroke-v2('stroke-2-v2');
+        border-color: rgb(var(--v-theme-red-500-v2));
+        background-color: rgb(var(--v-theme-red-500-v2));
+      }
+    }
+
+    &.v-input--disabled {
+      .v-selection-control {
+        opacity: 1;
+      }
+
+      .v-label {
+        color: rgb(var(--v-theme-text-secondary-v2));
+      }
+
+      .v-selection-control__input {
+        border-width: borders-v2.rc-stroke-v2('stroke-2-v2');
+        border-color: rgb(var(--v-theme-neutral-500-v2));
+        background-color: rgb(var(--v-theme-neutral-200-v2));
+        box-shadow: none;
+        opacity: 1 !important;
+
+        .v-icon {
+          opacity: 0;
+        }
+      }
+
+      &.rc-ses-checkbox-v2--checked .v-selection-control__input,
+      &.rc-ses-checkbox-v2--indeterminate .v-selection-control__input {
+        border-color: rgb(var(--v-theme-neutral-500-v2));
+        background-color: rgb(var(--v-theme-neutral-500-v2));
+
+        .v-icon {
+          color: rgb(var(--v-theme-text-inverse-v2));
+          opacity: 1;
+        }
+      }
+    }
+  }
+
+  &--loading {
+    display: inline-flex;
+    align-items: flex-start;
+    gap: spacing-v2.rc-spacing-v2('spacing-8-v2');
+    padding-block: spacing-v2.rc-spacing-v2('spacing-8-v2');
+    cursor: default;
+    pointer-events: none;
+  }
+
+  &__skeleton-control {
+    box-sizing: border-box;
+    display: block;
+    flex: none;
+    width: $checkbox-size;
+    height: $checkbox-size;
+    margin: spacing-v2.rc-spacing-v2('spacing-2-v2');
+    border-radius: borders-v2.rc-radius-v2('radius-4-v2');
+    background-color: rgb(var(--v-theme-neutral-100-v2));
+  }
+
+  &__skeleton-label {
+    display: block;
+    flex: none;
+    align-self: stretch;
+    width: 108px;
+    height: sizes-v2.rc-size-v2('size-16-v2');
+    margin-block: spacing-v2.rc-spacing-v2('spacing-4-v2');
+    border-radius: borders-v2.rc-radius-v2('radius-4-v2');
+    background: linear-gradient(
+        90deg,
+        rgba(var(--v-theme-neutral-200-v2), 0) 0%,
+        rgb(var(--v-theme-neutral-200-v2)) 70.19%,
+        rgba(var(--v-theme-neutral-200-v2), 0) 100%
+      ),
+      rgb(var(--v-theme-neutral-100-v2));
+    background-size: 200% 100%;
+    animation: rc-ses-checkbox-v2-skeleton 1.4s ease infinite;
+  }
+}
+
+@keyframes rc-ses-checkbox-v2-skeleton {
+  0% {
+    background-position: 100% 0;
+  }
+
+  100% {
+    background-position: -100% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rc-ses-checkbox-v2.v-checkbox .v-selection-control__input {
+    transition: none;
+  }
+
+  .rc-ses-checkbox-v2__skeleton-label {
+    animation: none;
+  }
+}

--- a/src/components/common/inputs/Checkboxes/CheckboxV2/types.ts
+++ b/src/components/common/inputs/Checkboxes/CheckboxV2/types.ts
@@ -1,0 +1,9 @@
+export type CheckboxProps = {
+  label?: string
+  showLabel?: boolean
+  disabled?: boolean
+  indeterminate?: boolean
+  loading?: boolean
+  error?: boolean | string
+  accessibleLabel?: string
+}

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -20,6 +20,8 @@ import RcSesButton from '@/components/common/buttons/Button/RcSesButton.vue'
 import RcSesFormControl from '@/components/common/forms/RcSesFormControl.vue'
 import RcSesCheckbox from '@/components/common/inputs/Checkboxes/Checkbox/RcSesCheckbox.vue'
 import RcSesCheckboxField from '@/components/common/inputs/Checkboxes/CheckboxField/RcSesCheckboxField.vue'
+import RcSesCheckboxSelectableAreaV2 from '@/components/common/inputs/Checkboxes/CheckboxSelectableAreaV2/RcSesCheckboxSelectableAreaV2.vue'
+import RcSesCheckboxV2 from '@/components/common/inputs/Checkboxes/CheckboxV2/RcSesCheckboxV2.vue'
 import RcSesDatePicker from '@/components/common/inputs/Datepickers/DatePicker/RcSesDatePicker.vue'
 import RcSesDatePickerField from '@/components/common/inputs/Datepickers/DatePickerField/RcSesDatePickerField.vue'
 import RcSesFieldWrapper from '@/components/common/inputs/FieldWrapper/RcSesFieldWrapper.vue'
@@ -133,6 +135,8 @@ export function createRcSesComponents(options: object = {}): Plugin<[]> {
     app.component('RcSesTooltip', RcSesTooltip)
 
     app.component('RcSesBadgeV2', RcSesBadgeV2)
+    app.component('RcSesCheckboxV2', RcSesCheckboxV2)
+    app.component('RcSesCheckboxSelectableAreaV2', RcSesCheckboxSelectableAreaV2)
     app.component('RcSesImageAndTextV2', RcSesImageAndTextV2)
     app.component('RcSesInlineAlertV2', RcSesInlineAlertV2)
     app.component('RcSesLoaderV2', RcSesLoaderV2)
@@ -162,7 +166,13 @@ export {
 }
 
 export { RcSesAlert, RcSesButton }
-export { RcSesBadgeV2, RcSesButtonV2, RcSesToggleV2 }
+export {
+  RcSesBadgeV2,
+  RcSesButtonV2,
+  RcSesCheckboxV2,
+  RcSesCheckboxSelectableAreaV2,
+  RcSesToggleV2,
+}
 export { RcSesImageAndTextV2, RcSesInlineAlertV2, RcSesStepperV2 }
 export { RcSesLoaderV2, RcSesFullPageLoaderV2 }
 export { RcSesModalV2, RcSesBackdropV2 }

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -49,6 +49,10 @@ const i18n = () => {
             close: 'Uždaryti',
           },
 
+          RcSesCheckboxV2: {
+            loading: 'Kraunama...',
+          },
+
           RcSesStepperV2: {
             back: 'Grįžti',
             completedStep: 'Užbaigta: {{step}}',
@@ -121,6 +125,10 @@ const i18n = () => {
 
           RcSesInlineAlertV2: {
             close: 'Close',
+          },
+
+          RcSesCheckboxV2: {
+            loading: 'Loading...',
           },
 
           RcSesStepperV2: {

--- a/src/stories/components v2/Checkbox/Checkbox.stories.ts
+++ b/src/stories/components v2/Checkbox/Checkbox.stories.ts
@@ -1,0 +1,95 @@
+import type { Meta, StoryFn } from '@storybook/vue3'
+import { ref } from 'vue'
+
+import RcSesCheckboxV2 from '@/components/common/inputs/Checkboxes/CheckboxV2/RcSesCheckboxV2.vue'
+import type { CheckboxProps } from '@/components/common/inputs/Checkboxes/CheckboxV2/types'
+
+const meta: Meta<typeof RcSesCheckboxV2> = {
+  title: 'componentsV2/Checkbox',
+  component: RcSesCheckboxV2,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Visible checkbox label',
+    },
+    showLabel: {
+      control: 'boolean',
+      description: 'Toggle the visible label',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    indeterminate: {
+      control: 'boolean',
+      description: 'Mixed parent state for sub-lists',
+    },
+    loading: {
+      control: 'boolean',
+    },
+    error: {
+      control: 'text',
+      description: 'Error state (boolean or message string)',
+    },
+    accessibleLabel: {
+      control: 'text',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryFn<typeof RcSesCheckboxV2>
+
+const checkboxDefaultArgs: Partial<CheckboxProps> = {
+  label: 'Checkbox text',
+  showLabel: true,
+  disabled: false,
+  indeterminate: false,
+  loading: false,
+  error: false,
+}
+
+export const Default: Story = (args) => ({
+  components: { RcSesCheckboxV2 },
+  setup() {
+    const value = ref(false)
+
+    return { args, value }
+  },
+  template: `
+    <RcSesCheckboxV2 v-bind="args" v-model="value" />
+  `,
+})
+Default.args = checkboxDefaultArgs as Meta<typeof RcSesCheckboxV2>['args']
+
+export const States: Story = () => ({
+  components: { RcSesCheckboxV2 },
+  setup() {
+    return {
+      unchecked: ref(false),
+      checked: ref(true),
+      indeterminate: ref(false),
+      disabledUnchecked: ref(false),
+      disabledChecked: ref(true),
+      errorUnchecked: ref(false),
+      errorChecked: ref(true),
+    }
+  },
+  template: `
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <RcSesCheckboxV2 v-model="unchecked" label="Unselected" />
+      <RcSesCheckboxV2 v-model="checked" label="Selected" />
+      <RcSesCheckboxV2 v-model="indeterminate" label="Indeterminate" indeterminate />
+      <RcSesCheckboxV2 v-model="disabledUnchecked" label="Disabled" disabled />
+      <RcSesCheckboxV2 v-model="disabledChecked" label="Disabled selected" disabled />
+      <RcSesCheckboxV2
+        v-model="errorUnchecked"
+        label="Error"
+        error="Privalomas laukas"
+      />
+      <RcSesCheckboxV2 v-model="errorChecked" label="Error selected" error />
+      <RcSesCheckboxV2 label="Loading" loading />
+    </div>
+  `,
+})

--- a/src/stories/components v2/CheckboxSelectableArea/CheckboxSelectableArea.stories.ts
+++ b/src/stories/components v2/CheckboxSelectableArea/CheckboxSelectableArea.stories.ts
@@ -1,0 +1,122 @@
+import type { Meta, StoryFn } from '@storybook/vue3'
+import { ref } from 'vue'
+
+import RcSesCheckboxSelectableAreaV2 from '@/components/common/inputs/Checkboxes/CheckboxSelectableAreaV2/RcSesCheckboxSelectableAreaV2.vue'
+import type { CheckboxSelectableAreaProps } from '@/components/common/inputs/Checkboxes/CheckboxSelectableAreaV2/types'
+
+const meta: Meta<typeof RcSesCheckboxSelectableAreaV2> = {
+  title: 'componentsV2/CheckboxSelectableArea',
+  component: RcSesCheckboxSelectableAreaV2,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Optional heading (Heading=true in Figma)',
+    },
+    description: {
+      control: 'text',
+    },
+    trailing: {
+      control: 'text',
+      description: 'Trailing value, e.g. price',
+    },
+    disabled: { control: 'boolean' },
+    indeterminate: { control: 'boolean' },
+    loading: { control: 'boolean' },
+    error: { control: 'boolean' },
+  },
+}
+
+export default meta
+
+type Story = StoryFn<typeof RcSesCheckboxSelectableAreaV2>
+
+const defaultArgs: Partial<CheckboxSelectableAreaProps> = {
+  title: 'Title',
+  description: 'Description text',
+  trailing: '00,00 €',
+  disabled: false,
+  loading: false,
+  error: false,
+}
+
+export const WithHeading: Story = (args) => ({
+  components: { RcSesCheckboxSelectableAreaV2 },
+  setup() {
+    const value = ref(false)
+
+    return { args, value }
+  },
+  template: `
+    <div style="max-width: 436px;">
+      <RcSesCheckboxSelectableAreaV2 v-bind="args" v-model="value" />
+    </div>
+  `,
+})
+WithHeading.args = defaultArgs as Meta<typeof RcSesCheckboxSelectableAreaV2>['args']
+
+export const DescriptionOnly: Story = () => ({
+  components: { RcSesCheckboxSelectableAreaV2 },
+  setup() {
+    const value = ref(true)
+
+    return { value }
+  },
+  template: `
+    <div style="max-width: 436px;">
+      <RcSesCheckboxSelectableAreaV2
+        v-model="value"
+        description="Description text"
+        trailing="00,00 €"
+      />
+    </div>
+  `,
+})
+
+export const States: Story = () => ({
+  components: { RcSesCheckboxSelectableAreaV2 },
+  setup() {
+    return {
+      rest: ref(false),
+      selected: ref(true),
+      disabled: ref(false),
+      error: ref(false),
+    }
+  },
+  template: `
+    <div style="display: flex; flex-direction: column; gap: 12px; max-width: 436px;">
+      <RcSesCheckboxSelectableAreaV2
+        v-model="rest"
+        title="Title"
+        description="Description text"
+        trailing="00,00 €"
+      />
+      <RcSesCheckboxSelectableAreaV2
+        v-model="selected"
+        title="Title"
+        description="Description text"
+        trailing="00,00 €"
+      />
+      <RcSesCheckboxSelectableAreaV2
+        v-model="disabled"
+        title="Title"
+        description="Description text"
+        trailing="00,00 €"
+        disabled
+      />
+      <RcSesCheckboxSelectableAreaV2
+        v-model="error"
+        title="Title"
+        description="Description text"
+        trailing="00,00 €"
+        error
+      />
+      <RcSesCheckboxSelectableAreaV2
+        title="Title"
+        description="Description text"
+        trailing="00,00 €"
+        loading
+      />
+    </div>
+  `,
+})

--- a/src/styles/vuetify/_sizes-v2.scss
+++ b/src/styles/vuetify/_sizes-v2.scss
@@ -31,6 +31,9 @@ $rc-size-v2-semantic: (
   'toggle-track-width-v2': 'size-36-v2',
   'toggle-track-height-v2': 'size-20-v2',
   'toggle-thumb-size-v2': 'size-16-v2',
+  // Checkbox
+  'checkbox-size-v2': 'size-20-v2',
+  'checkbox-icon-size-v2': 'size-16-v2',
 );
 
 @function rc-size-v2($token) {


### PR DESCRIPTION
## 🔗 Task

https://jira.registrucentras.lt/jira/browse/IRM-5284

@tomas562  @saukaite 

## 🧾 Summary

Adds RcSesCheckboxV2 — v2 checkbox on v-checkbox with Figma states (rest, hover, focus, disabled, error, loading), optional label (showLabel), accessibleLabel, indeterminate, and error helper (body-caption-v2, error-border-v2). Styling uses v2 tokens. Includes Storybook, tests, i18n, and library export.

Adds RcSesCheckboxSelectableAreaV2 — v2 clickable row (checkbox + optional title/description + trailing) with Figma area states and description-only layout. Wraps RcSesCheckboxV2; styling uses v2 tokens. Includes Storybook, tests, and library export.

## 📸 Screenshots

<img width="1042" height="696" alt="image" src="https://github.com/user-attachments/assets/0d0bfae3-51fd-4c2b-89b2-323e8761ed06" />
<img width="1046" height="763" alt="image" src="https://github.com/user-attachments/assets/23659882-751f-4164-b0f3-aebee50b7bc0" />


## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [x] UI matches approved design (Figma)
* [x] Accessibility reviewed (keyboard navigation, labels, semantics)
