### PR TITLE
IRM-5287 (RadioV2, RadioSelectableAreaV2, RadioGroupV2)

### DIFF
--- a/src/components/common/inputs/Radios/RadioGroupV2/RcSesRadioGroupV2.test.ts
+++ b/src/components/common/inputs/Radios/RadioGroupV2/RcSesRadioGroupV2.test.ts
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/vue'
+import I18NextVue from 'i18next-vue'
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+
+import RcSesRadioGroupV2 from '@/components/common/inputs/Radios/RadioGroupV2/RcSesRadioGroupV2.vue'
+import type { RadioGroupProps } from '@/components/common/inputs/Radios/RadioGroupV2/types'
+import RcSesRadioV2 from '@/components/common/inputs/Radios/RadioV2/RcSesRadioV2.vue'
+import initI18n from '@/plugins/i18n'
+
+const { i18next } = initI18n()
+
+const renderGroup = (
+  groupProps: Partial<RadioGroupProps> & {
+    modelValue?: string | number | boolean | null
+  } = {},
+) => {
+  const { modelValue, ...restGroupProps } = groupProps
+  const model = ref(modelValue ?? null)
+
+  return render(
+    {
+      components: { RcSesRadioGroupV2, RcSesRadioV2 },
+      setup() {
+        return {
+          model,
+          restGroupProps,
+        }
+      },
+      template: `
+        <RcSesRadioGroupV2 v-model="model" v-bind="restGroupProps">
+          <RcSesRadioV2 value="a" label="Option A" />
+          <RcSesRadioV2 value="b" label="Option B" />
+        </RcSesRadioGroupV2>
+      `,
+    },
+    {
+      global: {
+        plugins: [[I18NextVue, { i18next }]],
+        stubs: {
+          VRadio: true,
+        },
+      },
+    },
+  )
+}
+
+describe('RcSesRadioGroupV2', () => {
+  it('exposes accessible label on the radiogroup', () => {
+    renderGroup({ accessibleLabel: 'Mokėjimas' })
+
+    expect(screen.getByRole('radiogroup', { name: 'Mokėjimas' })).toBeInTheDocument()
+  })
+
+  it('shows error message when error is a string', () => {
+    renderGroup({ error: 'Privalomas laukas' })
+
+    expect(screen.getByText('Privalomas laukas')).toBeInTheDocument()
+  })
+
+  it('marks the radiogroup as invalid when error is set', () => {
+    renderGroup({ error: true, accessibleLabel: 'Pasirinkimas' })
+
+    expect(screen.getByRole('radiogroup')).toHaveAttribute('aria-invalid', 'true')
+  })
+})

--- a/src/components/common/inputs/Radios/RadioGroupV2/RcSesRadioGroupV2.vue
+++ b/src/components/common/inputs/Radios/RadioGroupV2/RcSesRadioGroupV2.vue
@@ -1,0 +1,66 @@
+<template>
+  <fieldset
+    :class="[
+      'rc-ses-radio-group-v2',
+      {
+        'rc-ses-radio-group-v2--disabled': props.disabled,
+        'rc-ses-radio-group-v2--error': hasError,
+      },
+    ]"
+    role="radiogroup"
+    :disabled="props.disabled || undefined"
+    :aria-label="props.accessibleLabel"
+    :aria-invalid="hasError || undefined"
+    :aria-describedby="errorDescribedBy"
+  >
+    <div class="rc-ses-radio-group-v2__options">
+      <slot />
+    </div>
+
+    <p v-if="errorMessage" :id="errorId" class="rc-ses-radio-group-v2__error">
+      {{ errorMessage }}
+    </p>
+  </fieldset>
+</template>
+
+<script setup lang="ts">
+import { computed, getCurrentInstance, provide } from 'vue'
+
+import {
+  type RadioGroupValue,
+  radioGroupV2Key,
+} from '@/components/common/inputs/Radios/RadioGroupV2/context'
+import radioGroupV2Defaults from '@/components/common/inputs/Radios/RadioGroupV2/defaults'
+import type { RadioGroupProps } from '@/components/common/inputs/Radios/RadioGroupV2/types'
+
+import './style.scss'
+
+const props = withDefaults(defineProps<RadioGroupProps>(), radioGroupV2Defaults)
+
+const model = defineModel<RadioGroupValue>({ default: null })
+
+const errorId = `rc-ses-radio-group-error-${getCurrentInstance()?.uid ?? '0'}`
+
+const hasError = computed(() => Boolean(props.error))
+
+const errorMessage = computed(() =>
+  typeof props.error === 'string' ? props.error : undefined,
+)
+
+const errorDescribedBy = computed(() => (errorMessage.value ? errorId : undefined))
+
+const select = (value: string | number | boolean) => {
+  if (props.disabled) {
+    return
+  }
+
+  model.value = value
+}
+
+provide(radioGroupV2Key, {
+  model,
+  disabled: computed(() => props.disabled),
+  hasError,
+  select,
+})
+</script>

--- a/src/components/common/inputs/Radios/RadioGroupV2/context.ts
+++ b/src/components/common/inputs/Radios/RadioGroupV2/context.ts
@@ -1,0 +1,13 @@
+import type { ComputedRef, InjectionKey, Ref } from 'vue'
+
+export type RadioGroupValue = string | number | boolean | null
+
+export type RadioGroupV2Context = {
+  model: Ref<RadioGroupValue>
+  disabled: ComputedRef<boolean>
+  hasError: ComputedRef<boolean>
+  select: (value: string | number | boolean) => void
+}
+
+export const radioGroupV2Key: InjectionKey<RadioGroupV2Context> =
+  Symbol('RcSesRadioGroupV2')

--- a/src/components/common/inputs/Radios/RadioGroupV2/defaults.ts
+++ b/src/components/common/inputs/Radios/RadioGroupV2/defaults.ts
@@ -1,0 +1,11 @@
+export type RadioGroupDefaultsType = {
+  disabled: boolean
+  error: boolean
+}
+
+const radioGroupV2Defaults = {
+  disabled: false,
+  error: false,
+} satisfies RadioGroupDefaultsType
+
+export default radioGroupV2Defaults

--- a/src/components/common/inputs/Radios/RadioGroupV2/style.scss
+++ b/src/components/common/inputs/Radios/RadioGroupV2/style.scss
@@ -1,0 +1,30 @@
+@use '/src/styles/vuetify/sizes-v2' as sizes-v2;
+@use '/src/styles/vuetify/spacing-v2' as spacing-v2;
+@use '/src/styles/vuetify/typography-v2' as typography-v2;
+
+.rc-ses-radio-group-v2 {
+  $radio-container-size: sizes-v2.rc-size-v2('size-24-v2');
+
+  margin: 0;
+  padding: 0;
+  border: none;
+  min-inline-size: 0;
+
+  &__options {
+    display: flex;
+    flex-direction: column;
+    gap: spacing-v2.rc-spacing-v2('spacing-8-v2');
+  }
+
+  &__error {
+    @include typography-v2.rc-typography-v2('body-caption-v2');
+
+    margin: 0;
+    margin-block-start: spacing-v2.rc-spacing-v2('spacing-4-v2');
+
+    padding-inline-start: calc(
+      #{$radio-container-size} + #{spacing-v2.rc-spacing-v2('spacing-8-v2')}
+    );
+    color: rgb(var(--v-theme-error-border-v2));
+  }
+}

--- a/src/components/common/inputs/Radios/RadioGroupV2/types.ts
+++ b/src/components/common/inputs/Radios/RadioGroupV2/types.ts
@@ -1,0 +1,5 @@
+export type RadioGroupProps = {
+  accessibleLabel?: string
+  disabled?: boolean
+  error?: boolean | string
+}

--- a/src/components/common/inputs/Radios/RadioSelectableAreaV2/RcSesRadioSelectableAreaV2.test.ts
+++ b/src/components/common/inputs/Radios/RadioSelectableAreaV2/RcSesRadioSelectableAreaV2.test.ts
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen } from '@testing-library/vue'
+import I18NextVue from 'i18next-vue'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+
+import RcSesRadioGroupV2 from '@/components/common/inputs/Radios/RadioGroupV2/RcSesRadioGroupV2.vue'
+import type { RadioGroupProps } from '@/components/common/inputs/Radios/RadioGroupV2/types'
+import RcSesRadioSelectableAreaV2 from '@/components/common/inputs/Radios/RadioSelectableAreaV2/RcSesRadioSelectableAreaV2.vue'
+import type { RadioSelectableAreaProps } from '@/components/common/inputs/Radios/RadioSelectableAreaV2/types'
+import initI18n from '@/plugins/i18n'
+
+const { i18next } = initI18n()
+
+const VRadioStub = defineComponent({
+  name: 'VRadio',
+  inheritAttrs: false,
+  props: {
+    value: { type: [String, Number, Boolean], default: undefined },
+    disabled: { type: Boolean, default: false },
+  },
+  emits: ['click'],
+  setup(radioProps, { attrs, emit }) {
+    return () =>
+      h(
+        'div',
+        {
+          class: ['v-radio', 'rc-ses-radio-v2', attrs.class],
+          onClick: (event: MouseEvent) => emit('click', event),
+        },
+        [
+          h('input', {
+            type: 'radio',
+            role: 'presentation',
+            disabled: radioProps.disabled,
+            value: radioProps.value,
+          }),
+        ],
+      )
+  },
+})
+
+const renderSelectableAreaInGroup = (
+  areaProps: Partial<RadioSelectableAreaProps> = {},
+  groupProps: Partial<RadioGroupProps> & {
+    modelValue?: string | number | boolean | null
+  } = {},
+) => {
+  const { modelValue, ...restGroupProps } = groupProps
+  const model = ref(modelValue ?? null)
+
+  return render(
+    {
+      components: { RcSesRadioGroupV2, RcSesRadioSelectableAreaV2 },
+      setup() {
+        return {
+          model,
+          restGroupProps,
+          areaProps: {
+            description: 'Description text',
+            value: 'option-a',
+            ...areaProps,
+          },
+        }
+      },
+      template: `
+        <RcSesRadioGroupV2 v-model="model" v-bind="restGroupProps">
+          <RcSesRadioSelectableAreaV2 v-bind="areaProps" />
+        </RcSesRadioGroupV2>
+      `,
+    },
+    {
+      global: {
+        plugins: [[I18NextVue, { i18next }]],
+        stubs: {
+          VRadio: VRadioStub,
+        },
+      },
+    },
+  )
+}
+
+describe('RcSesRadioSelectableAreaV2', () => {
+  it('renders description text', () => {
+    renderSelectableAreaInGroup()
+
+    expect(screen.getByText('Description text')).toBeInTheDocument()
+  })
+
+  it('renders title when provided', () => {
+    const { container } = renderSelectableAreaInGroup({ title: 'Title' })
+
+    expect(screen.getByText('Title')).toBeInTheDocument()
+    expect(container.querySelector('.rc-ses-radio-selectable-area-v2')).toHaveClass(
+      'rc-ses-radio-selectable-area-v2--with-heading',
+    )
+  })
+
+  it('renders trailing value when provided', () => {
+    renderSelectableAreaInGroup({ trailing: '00,00 €' })
+
+    expect(screen.getByText('00,00 €')).toBeInTheDocument()
+  })
+
+  it('selects value in the group when the area is clicked', async () => {
+    const { container } = renderSelectableAreaInGroup(
+      { value: 'card' },
+      { modelValue: null },
+    )
+
+    await fireEvent.click(screen.getByText('Description text'))
+
+    expect(container.querySelector('.rc-ses-radio-selectable-area-v2')).toHaveClass(
+      'rc-ses-radio-selectable-area-v2--checked',
+    )
+  })
+
+  it('applies checked modifier when group model matches value', () => {
+    const { container } = renderSelectableAreaInGroup(
+      { value: 'option-a' },
+      { modelValue: 'option-a' },
+    )
+
+    expect(container.querySelector('.rc-ses-radio-selectable-area-v2')).toHaveClass(
+      'rc-ses-radio-selectable-area-v2--checked',
+    )
+  })
+
+  it('does not change value when disabled', async () => {
+    const { container } = renderSelectableAreaInGroup(
+      { disabled: true, value: 'option-a' },
+      { modelValue: null },
+    )
+
+    await fireEvent.click(screen.getByText('Description text'))
+
+    expect(container.querySelector('.rc-ses-radio-selectable-area-v2')).not.toHaveClass(
+      'rc-ses-radio-selectable-area-v2--checked',
+    )
+  })
+
+  it('renders loading skeleton', () => {
+    const { container } = renderSelectableAreaInGroup({ loading: true })
+
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument()
+    expect(
+      container.querySelector('.rc-ses-radio-selectable-area-v2--loading'),
+    ).toBeInTheDocument()
+  })
+
+  it('exposes a single radio role on the area (visual radio is decorative)', () => {
+    renderSelectableAreaInGroup({ accessibleLabel: 'Payment card' })
+
+    expect(screen.getAllByRole('radio')).toHaveLength(1)
+    expect(screen.getByRole('radio', { name: 'Payment card' })).toBeInTheDocument()
+  })
+
+  it('selects via keyboard Enter', async () => {
+    const { container } = renderSelectableAreaInGroup(
+      { value: 'bank' },
+      { modelValue: null },
+    )
+
+    await fireEvent.keyDown(screen.getByRole('radio'), { key: 'Enter' })
+
+    expect(container.querySelector('.rc-ses-radio-selectable-area-v2')).toHaveClass(
+      'rc-ses-radio-selectable-area-v2--checked',
+    )
+  })
+})

--- a/src/components/common/inputs/Radios/RadioSelectableAreaV2/RcSesRadioSelectableAreaV2.test.ts
+++ b/src/components/common/inputs/Radios/RadioSelectableAreaV2/RcSesRadioSelectableAreaV2.test.ts
@@ -131,11 +131,13 @@ describe('RcSesRadioSelectableAreaV2', () => {
       { modelValue: null },
     )
 
+    const area = container.querySelector('.rc-ses-radio-selectable-area-v2')
+
+    expect(area).toHaveAttribute('tabindex', '-1')
+
     await fireEvent.click(screen.getByText('Description text'))
 
-    expect(container.querySelector('.rc-ses-radio-selectable-area-v2')).not.toHaveClass(
-      'rc-ses-radio-selectable-area-v2--checked',
-    )
+    expect(area).not.toHaveClass('rc-ses-radio-selectable-area-v2--checked')
   })
 
   it('renders loading skeleton', () => {

--- a/src/components/common/inputs/Radios/RadioSelectableAreaV2/RcSesRadioSelectableAreaV2.vue
+++ b/src/components/common/inputs/Radios/RadioSelectableAreaV2/RcSesRadioSelectableAreaV2.vue
@@ -29,6 +29,7 @@
     />
   </div>
 
+  <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -- :tabindex is 0 when enabled, -1 when disabled -->
   <div
     v-else
     :class="[
@@ -41,7 +42,7 @@
       },
     ]"
     role="radio"
-    tabindex="0"
+    :tabindex="isDisabled ? -1 : 0"
     :aria-checked="isSelected"
     :aria-disabled="isDisabled || undefined"
     :aria-label="radioAccessibleLabel"

--- a/src/components/common/inputs/Radios/RadioSelectableAreaV2/RcSesRadioSelectableAreaV2.vue
+++ b/src/components/common/inputs/Radios/RadioSelectableAreaV2/RcSesRadioSelectableAreaV2.vue
@@ -1,0 +1,122 @@
+<template>
+  <div
+    v-if="props.loading"
+    :class="[
+      'rc-ses-radio-selectable-area-v2',
+      'rc-ses-radio-selectable-area-v2--loading',
+      { 'rc-ses-radio-selectable-area-v2--with-heading': hasHeading },
+    ]"
+    role="status"
+    :aria-label="loadingAriaLabel"
+  >
+    <RcSesRadioV2
+      class="rc-ses-radio-selectable-area-v2__radio"
+      :value="props.value"
+      loading
+    />
+    <div class="rc-ses-radio-selectable-area-v2__content">
+      <span
+        v-if="hasHeading"
+        class="rc-ses-radio-selectable-area-v2__skeleton-line rc-ses-radio-selectable-area-v2__skeleton-line--title"
+      />
+      <span
+        class="rc-ses-radio-selectable-area-v2__skeleton-line rc-ses-radio-selectable-area-v2__skeleton-line--description"
+      />
+    </div>
+    <span
+      v-if="props.trailing"
+      class="rc-ses-radio-selectable-area-v2__skeleton-line rc-ses-radio-selectable-area-v2__skeleton-line--trailing"
+    />
+  </div>
+
+  <div
+    v-else
+    :class="[
+      'rc-ses-radio-selectable-area-v2',
+      {
+        'rc-ses-radio-selectable-area-v2--checked': isSelected,
+        'rc-ses-radio-selectable-area-v2--disabled': isDisabled,
+        'rc-ses-radio-selectable-area-v2--error': hasError,
+        'rc-ses-radio-selectable-area-v2--with-heading': hasHeading,
+      },
+    ]"
+    role="radio"
+    tabindex="0"
+    :aria-checked="isSelected"
+    :aria-disabled="isDisabled || undefined"
+    :aria-label="radioAccessibleLabel"
+    @click="handleAreaClick"
+    @keydown.enter.prevent="handleAreaClick"
+    @keydown.space.prevent="handleAreaClick"
+  >
+    <RcSesRadioV2
+      class="rc-ses-radio-selectable-area-v2__radio"
+      :value="props.value"
+      decorative
+      :show-label="false"
+      :disabled="props.disabled"
+    />
+
+    <div class="rc-ses-radio-selectable-area-v2__content">
+      <p v-if="hasHeading" class="rc-ses-radio-selectable-area-v2__title">
+        <slot name="title">{{ props.title }}</slot>
+      </p>
+      <p class="rc-ses-radio-selectable-area-v2__description">
+        <slot>{{ props.description }}</slot>
+      </p>
+    </div>
+
+    <span v-if="props.trailing" class="rc-ses-radio-selectable-area-v2__trailing">
+      <slot name="trailing">{{ props.trailing }}</slot>
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useTranslation } from 'i18next-vue'
+import { computed, inject } from 'vue'
+
+import { radioGroupV2Key } from '@/components/common/inputs/Radios/RadioGroupV2/context'
+import radioSelectableAreaV2Defaults from '@/components/common/inputs/Radios/RadioSelectableAreaV2/defaults'
+import type { RadioSelectableAreaProps } from '@/components/common/inputs/Radios/RadioSelectableAreaV2/types'
+import RcSesRadioV2 from '@/components/common/inputs/Radios/RadioV2/RcSesRadioV2.vue'
+
+import './style.scss'
+
+const props = withDefaults(
+  defineProps<RadioSelectableAreaProps>(),
+  radioSelectableAreaV2Defaults,
+)
+
+const { t } = useTranslation()
+
+const group = inject(radioGroupV2Key, null)
+
+const hasHeading = computed(() => Boolean(props.title))
+
+const isSelected = computed(() => group?.model.value === props.value)
+
+const isDisabled = computed(() => props.disabled || Boolean(group?.disabled.value))
+
+const hasError = computed(() => Boolean(group?.hasError.value))
+
+const radioAccessibleLabel = computed(
+  () => props.accessibleLabel ?? props.title ?? props.description,
+)
+
+const loadingAriaLabel = computed(
+  () =>
+    props.accessibleLabel ??
+    props.title ??
+    props.description ??
+    t('RcSesRadioV2.loading', { ns: 'components' }),
+)
+
+const handleAreaClick = () => {
+  if (isDisabled.value) {
+    return
+  }
+
+  group?.select(props.value)
+}
+</script>

--- a/src/components/common/inputs/Radios/RadioSelectableAreaV2/defaults.ts
+++ b/src/components/common/inputs/Radios/RadioSelectableAreaV2/defaults.ts
@@ -1,0 +1,11 @@
+export type RadioSelectableAreaDefaultsType = {
+  disabled: boolean
+  loading: boolean
+}
+
+const radioSelectableAreaV2Defaults = {
+  disabled: false,
+  loading: false,
+} satisfies RadioSelectableAreaDefaultsType
+
+export default radioSelectableAreaV2Defaults

--- a/src/components/common/inputs/Radios/RadioSelectableAreaV2/style.scss
+++ b/src/components/common/inputs/Radios/RadioSelectableAreaV2/style.scss
@@ -1,0 +1,206 @@
+@use '/src/styles/vuetify/borders-v2' as borders-v2;
+@use '/src/styles/vuetify/sizes-v2' as sizes-v2;
+@use '/src/styles/vuetify/spacing-v2' as spacing-v2;
+@use '/src/styles/vuetify/typography-v2' as typography-v2;
+
+.rc-ses-radio-selectable-area-v2 {
+  box-sizing: border-box;
+  display: flex;
+  align-items: flex-start;
+  gap: spacing-v2.rc-spacing-v2('spacing-8-v2');
+  width: 100%;
+  padding: spacing-v2.rc-spacing-v2('spacing-8-v2')
+    spacing-v2.rc-spacing-v2('spacing-12-v2');
+  border: borders-v2.rc-stroke-v2('stroke-2-v2') solid transparent;
+  border-radius: borders-v2.rc-radius-v2('radius-6-v2');
+  background-color: rgb(var(--v-theme-surface-base-v2));
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
+
+  &__radio {
+    flex-shrink: 0;
+
+    &.rc-ses-radio-v2.v-selection-control,
+    &.rc-ses-radio-v2.v-radio,
+    &.rc-ses-radio-v2--decorative {
+      min-height: sizes-v2.rc-size-v2('size-24-v2') !important;
+      padding-block: 0;
+    }
+
+    &.rc-ses-radio-v2--loading {
+      padding-block: 0;
+    }
+  }
+
+  &__content {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    justify-content: flex-start;
+    gap: spacing-v2.rc-spacing-v2('spacing-2-v2');
+    min-width: 0;
+  }
+
+  &__title {
+    @include typography-v2.rc-typography-v2('body-large-v2');
+
+    margin: 0;
+    color: rgb(var(--v-theme-text-default-v2));
+  }
+
+  &__description {
+    @include typography-v2.rc-typography-v2('body-large-v2');
+
+    margin: 0;
+    color: rgb(var(--v-theme-neutral-800-v2));
+  }
+
+  &--with-heading &__description {
+    @include typography-v2.rc-typography-v2('body-small-v2');
+  }
+
+  &__trailing {
+    @include typography-v2.rc-typography-v2('body-large-v2');
+
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: flex-end;
+    gap: spacing-v2.rc-spacing-v2('spacing-4-v2');
+    margin-inline-start: auto;
+    color: rgb(var(--v-theme-text-default-v2));
+    text-align: right;
+    white-space: nowrap;
+  }
+
+  &__skeleton-line {
+    display: block;
+    border-radius: borders-v2.rc-radius-v2('radius-4-v2');
+    background:
+      linear-gradient(
+        90deg,
+        rgba(var(--v-theme-neutral-200-v2), 0) 0%,
+        rgb(var(--v-theme-neutral-200-v2)) 70.19%,
+        rgba(var(--v-theme-neutral-200-v2), 0) 100%
+      ),
+      rgb(var(--v-theme-neutral-100-v2));
+    background-size: 200% 100%;
+    animation: rc-ses-radio-selectable-area-v2-skeleton 1.4s ease infinite;
+
+    &--title {
+      width: 200px;
+      height: sizes-v2.rc-size-v2('size-20-v2');
+      margin-block: spacing-v2.rc-spacing-v2('spacing-2-v2');
+    }
+
+    &--description {
+      width: 100%;
+      max-width: 320px;
+      height: sizes-v2.rc-size-v2('size-16-v2');
+      margin-block: spacing-v2.rc-spacing-v2('spacing-2-v2');
+    }
+
+    &--trailing {
+      flex-grow: 1;
+      width: 56px;
+      height: sizes-v2.rc-size-v2('size-16-v2');
+      margin-block: spacing-v2.rc-spacing-v2('spacing-4-v2');
+    }
+  }
+
+  &:hover:not(.rc-ses-radio-selectable-area-v2--disabled):not(
+      .rc-ses-radio-selectable-area-v2--loading
+    ):not(.rc-ses-radio-selectable-area-v2--checked):not(
+      .rc-ses-radio-selectable-area-v2--error
+    ):not(:focus-visible) {
+    background-color: rgb(var(--v-theme-neutral-100-v2));
+
+    .rc-ses-radio-v2 .v-selection-control__input {
+      border-color: rgb(var(--v-theme-cyan-500-v2));
+      box-shadow: 0 0 0 #{borders-v2.rc-stroke-v2('stroke-4-v2')}
+        rgba(var(--v-theme-cyan-400-v2), 0.2);
+    }
+  }
+
+  &:focus-visible:not(.rc-ses-radio-selectable-area-v2--disabled):not(
+      .rc-ses-radio-selectable-area-v2--loading
+    ) {
+    border-color: rgb(var(--v-theme-border-focus-actual-v2));
+    outline: none;
+
+    .rc-ses-radio-v2 .v-selection-control__input {
+      box-shadow: none;
+      outline: borders-v2.rc-stroke-v2('border-width-focus-v2') solid
+        rgb(var(--v-theme-border-focus-actual-v2));
+      outline-offset: borders-v2.rc-stroke-v2('stroke-2-v2');
+    }
+  }
+
+  &--checked {
+    border-color: rgb(var(--v-theme-cyan-500-v2));
+    background-color: rgb(var(--v-theme-cyan-50-v2));
+  }
+
+  &--error {
+    border-color: rgb(var(--v-theme-red-600-v2));
+
+    &:hover:not(.rc-ses-radio-selectable-area-v2--disabled):not(:focus-visible) {
+      background-color: rgb(var(--v-theme-red-50-v2));
+
+      .rc-ses-radio-v2 .v-selection-control__input {
+        border-color: rgb(var(--v-theme-red-500-v2));
+        box-shadow: 0 0 0 #{borders-v2.rc-stroke-v2('stroke-4-v2')}
+          rgba(var(--v-theme-red-600-v2), 0.2);
+      }
+    }
+  }
+
+  &--disabled {
+    cursor: not-allowed;
+
+    .rc-ses-radio-selectable-area-v2__title,
+    .rc-ses-radio-selectable-area-v2__description,
+    .rc-ses-radio-selectable-area-v2__trailing {
+      color: rgb(var(--v-theme-text-secondary-v2));
+    }
+  }
+
+  &--loading {
+    cursor: default;
+    pointer-events: none;
+  }
+
+  &--with-heading {
+    align-items: flex-start;
+  }
+
+  &:not(.rc-ses-radio-selectable-area-v2--with-heading) {
+    align-items: center;
+
+    .rc-ses-radio-selectable-area-v2__trailing {
+      align-self: center;
+    }
+  }
+}
+
+@keyframes rc-ses-radio-selectable-area-v2-skeleton {
+  0% {
+    background-position: 100% 0;
+  }
+
+  100% {
+    background-position: -100% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rc-ses-radio-selectable-area-v2 {
+    transition: none;
+  }
+
+  .rc-ses-radio-selectable-area-v2__skeleton-line {
+    animation: none;
+  }
+}

--- a/src/components/common/inputs/Radios/RadioSelectableAreaV2/types.ts
+++ b/src/components/common/inputs/Radios/RadioSelectableAreaV2/types.ts
@@ -1,0 +1,9 @@
+export type RadioSelectableAreaProps = {
+  value: string | number | boolean
+  title?: string
+  description: string
+  trailing?: string
+  disabled?: boolean
+  loading?: boolean
+  accessibleLabel?: string
+}

--- a/src/components/common/inputs/Radios/RadioV2/RcSesRadioV2.test.ts
+++ b/src/components/common/inputs/Radios/RadioV2/RcSesRadioV2.test.ts
@@ -21,7 +21,7 @@ const VRadioStub = defineComponent({
     trueIcon: { type: String, default: undefined },
     falseIcon: { type: String, default: undefined },
   },
-  emits: ['click'],
+  emits: ['update:modelValue'],
   setup(radioProps, { attrs, slots, emit }) {
     return () =>
       h(
@@ -32,7 +32,11 @@ const VRadioStub = defineComponent({
           'aria-label': attrs['aria-label'],
           'aria-checked': attrs['aria-checked'],
           'aria-disabled': radioProps.disabled || undefined,
-          onClick: (event: MouseEvent) => emit('click', event),
+          onClick: () => {
+            if (!radioProps.disabled) {
+              emit('update:modelValue', radioProps.value)
+            }
+          },
         },
         [
           h('input', {

--- a/src/components/common/inputs/Radios/RadioV2/RcSesRadioV2.test.ts
+++ b/src/components/common/inputs/Radios/RadioV2/RcSesRadioV2.test.ts
@@ -1,0 +1,157 @@
+import { fireEvent, render, screen } from '@testing-library/vue'
+import I18NextVue from 'i18next-vue'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
+
+import RcSesRadioGroupV2 from '@/components/common/inputs/Radios/RadioGroupV2/RcSesRadioGroupV2.vue'
+import type { RadioGroupProps } from '@/components/common/inputs/Radios/RadioGroupV2/types'
+import RcSesRadioV2 from '@/components/common/inputs/Radios/RadioV2/RcSesRadioV2.vue'
+import type { RadioProps } from '@/components/common/inputs/Radios/RadioV2/types'
+import initI18n from '@/plugins/i18n'
+
+const { i18next } = initI18n()
+
+const VRadioStub = defineComponent({
+  name: 'VRadio',
+  inheritAttrs: false,
+  props: {
+    value: { type: [String, Number, Boolean], default: undefined },
+    label: { type: String, default: undefined },
+    disabled: { type: Boolean, default: false },
+    trueIcon: { type: String, default: undefined },
+    falseIcon: { type: String, default: undefined },
+  },
+  emits: ['click'],
+  setup(radioProps, { attrs, slots, emit }) {
+    return () =>
+      h(
+        'div',
+        {
+          class: ['v-radio', 'v-selection-control', 'rc-ses-radio-v2', attrs.class],
+          role: 'radio',
+          'aria-label': attrs['aria-label'],
+          'aria-checked': attrs['aria-checked'],
+          'aria-disabled': radioProps.disabled || undefined,
+          onClick: (event: MouseEvent) => emit('click', event),
+        },
+        [
+          h('input', {
+            type: 'radio',
+            role: 'presentation',
+            tabindex: -1,
+            disabled: radioProps.disabled,
+            value: radioProps.value,
+          }),
+          radioProps.label ? h('label', {}, radioProps.label) : slots.label?.(),
+        ],
+      )
+  },
+})
+
+const renderRadioInGroup = (
+  radioProps: Partial<RadioProps> = {},
+  groupProps: Partial<RadioGroupProps> & {
+    modelValue?: string | number | boolean | null
+  } = {},
+) => {
+  const { modelValue, ...restGroupProps } = groupProps
+  const model = ref(modelValue ?? null)
+
+  return render(
+    {
+      components: { RcSesRadioGroupV2, RcSesRadioV2 },
+      setup() {
+        return {
+          model,
+          restGroupProps,
+          radioProps: {
+            label: 'Radio text',
+            value: 'option-a',
+            ...radioProps,
+          },
+        }
+      },
+      template: `
+        <RcSesRadioGroupV2 v-model="model" v-bind="restGroupProps">
+          <RcSesRadioV2 v-bind="radioProps" />
+        </RcSesRadioGroupV2>
+      `,
+    },
+    {
+      global: {
+        plugins: [[I18NextVue, { i18next }]],
+        stubs: {
+          VRadio: VRadioStub,
+        },
+      },
+    },
+  )
+}
+
+describe('RcSesRadioV2', () => {
+  it('renders the label text', () => {
+    renderRadioInGroup()
+
+    expect(screen.getByText('Radio text')).toBeInTheDocument()
+  })
+
+  it('applies checked modifier when group model matches value', () => {
+    const { container } = renderRadioInGroup(
+      { value: 'option-a' },
+      { modelValue: 'option-a' },
+    )
+
+    expect(container.querySelector('.rc-ses-radio-v2')).toHaveClass(
+      'rc-ses-radio-v2--checked',
+    )
+  })
+
+  it('applies error modifier when group has error', () => {
+    const { container } = renderRadioInGroup({}, { error: true })
+
+    expect(container.querySelector('.rc-ses-radio-v2')).toHaveClass(
+      'rc-ses-radio-v2--error',
+    )
+  })
+
+  it('selects value in the group when clicked', async () => {
+    const { container } = renderRadioInGroup({ value: 'option-a' }, { modelValue: null })
+
+    await fireEvent.click(screen.getByRole('radio'))
+
+    expect(container.querySelector('.rc-ses-radio-v2')).toHaveClass(
+      'rc-ses-radio-v2--checked',
+    )
+  })
+
+  it('renders loading skeleton instead of the control', () => {
+    const { container } = renderRadioInGroup({ loading: true })
+
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument()
+    expect(container.querySelector('.rc-ses-radio-v2--loading')).toBeInTheDocument()
+  })
+
+  it('hides the label when showLabel is false', () => {
+    renderRadioInGroup({ showLabel: false, accessibleLabel: 'Pasirinkti' })
+
+    expect(screen.queryByText('Radio text')).not.toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'Pasirinkti' })).toBeInTheDocument()
+  })
+
+  it('does not toggle when disabled', async () => {
+    const { container } = renderRadioInGroup(
+      { disabled: true, value: 'option-a' },
+      { modelValue: null },
+    )
+
+    expect(container.querySelector('.rc-ses-radio-v2')).toHaveClass(
+      'rc-ses-radio-v2--disabled',
+    )
+
+    await fireEvent.click(screen.getByRole('radio'))
+
+    expect(container.querySelector('.rc-ses-radio-v2')).not.toHaveClass(
+      'rc-ses-radio-v2--checked',
+    )
+  })
+})

--- a/src/components/common/inputs/Radios/RadioV2/RcSesRadioV2.vue
+++ b/src/components/common/inputs/Radios/RadioV2/RcSesRadioV2.vue
@@ -53,7 +53,6 @@
     density="compact"
     :ripple="false"
     @update:model-value="handleVuetifyUpdate"
-    @click="handleClick"
   >
     <template v-if="$slots.default" #label>
       <slot />
@@ -111,10 +110,6 @@ const selectValue = () => {
   }
 
   group?.select(props.value)
-}
-
-const handleClick = () => {
-  selectValue()
 }
 
 const handleVuetifyUpdate = (value: unknown) => {

--- a/src/components/common/inputs/Radios/RadioV2/RcSesRadioV2.vue
+++ b/src/components/common/inputs/Radios/RadioV2/RcSesRadioV2.vue
@@ -1,0 +1,125 @@
+<template>
+  <div
+    v-if="props.loading"
+    class="rc-ses-radio-v2 rc-ses-radio-v2--loading"
+    role="status"
+    :aria-label="loadingAriaLabel"
+  >
+    <span class="rc-ses-radio-v2__skeleton-control" aria-hidden="true" />
+    <span
+      v-if="props.showLabel && props.label"
+      class="rc-ses-radio-v2__skeleton-label"
+      aria-hidden="true"
+    />
+  </div>
+
+  <div
+    v-else-if="props.decorative"
+    aria-hidden="true"
+    :class="[
+      'rc-ses-radio-v2',
+      'rc-ses-radio-v2--decorative',
+      'v-selection-control',
+      {
+        'rc-ses-radio-v2--checked': isSelected,
+        'rc-ses-radio-v2--disabled': isDisabled,
+        'rc-ses-radio-v2--error': hasError,
+      },
+    ]"
+  >
+    <div class="v-selection-control__wrapper">
+      <div class="v-selection-control__input" />
+    </div>
+  </div>
+
+  <v-radio
+    v-else
+    :class="[
+      'rc-ses-radio-v2',
+      {
+        'rc-ses-radio-v2--checked': isSelected,
+        'rc-ses-radio-v2--disabled': isDisabled,
+        'rc-ses-radio-v2--error': hasError,
+      },
+    ]"
+    :model-value="vuetifyModelValue"
+    :value="props.value"
+    :label="displayLabel"
+    :aria-label="ariaLabelValue"
+    :aria-checked="isSelected"
+    :disabled="isDisabled"
+    :true-icon="trueIcon"
+    :false-icon="falseIcon"
+    density="compact"
+    :ripple="false"
+    @update:model-value="handleVuetifyUpdate"
+    @click="handleClick"
+  >
+    <template v-if="$slots.default" #label>
+      <slot />
+    </template>
+  </v-radio>
+</template>
+
+<script setup lang="ts">
+import { useTranslation } from 'i18next-vue'
+import { computed, inject } from 'vue'
+
+import { radioGroupV2Key } from '@/components/common/inputs/Radios/RadioGroupV2/context'
+import radioV2Defaults from '@/components/common/inputs/Radios/RadioV2/defaults'
+import type { RadioProps } from '@/components/common/inputs/Radios/RadioV2/types'
+
+import './style.scss'
+
+const props = withDefaults(defineProps<RadioProps>(), radioV2Defaults)
+
+const { t } = useTranslation()
+
+const group = inject(radioGroupV2Key, null)
+
+const trueIcon = '$radioOn'
+const falseIcon = '$radioOff'
+
+const isSelected = computed(() => group?.model.value === props.value)
+
+const vuetifyModelValue = computed(() => (isSelected.value ? props.value : null))
+
+const isDisabled = computed(() => props.disabled || Boolean(group?.disabled.value))
+
+const hasError = computed(() => Boolean(group?.hasError.value))
+
+const displayLabel = computed(() => (props.showLabel ? props.label : undefined))
+
+const ariaLabelValue = computed(() => {
+  if (props.showLabel && props.label) {
+    return undefined
+  }
+
+  return props.accessibleLabel ?? props.label
+})
+
+const loadingAriaLabel = computed(
+  () =>
+    props.accessibleLabel ??
+    props.label ??
+    t('RcSesRadioV2.loading', { ns: 'components' }),
+)
+
+const selectValue = () => {
+  if (isDisabled.value || props.decorative) {
+    return
+  }
+
+  group?.select(props.value)
+}
+
+const handleClick = () => {
+  selectValue()
+}
+
+const handleVuetifyUpdate = (value: unknown) => {
+  if (value === props.value) {
+    selectValue()
+  }
+}
+</script>

--- a/src/components/common/inputs/Radios/RadioV2/defaults.ts
+++ b/src/components/common/inputs/Radios/RadioV2/defaults.ts
@@ -1,0 +1,15 @@
+export type RadioDefaultsType = {
+  showLabel: boolean
+  disabled: boolean
+  loading: boolean
+  decorative: boolean
+}
+
+const radioV2Defaults = {
+  showLabel: true,
+  disabled: false,
+  loading: false,
+  decorative: false,
+} satisfies RadioDefaultsType
+
+export default radioV2Defaults

--- a/src/components/common/inputs/Radios/RadioV2/style.scss
+++ b/src/components/common/inputs/Radios/RadioV2/style.scss
@@ -1,0 +1,211 @@
+@use '/src/styles/vuetify/borders-v2' as borders-v2;
+@use '/src/styles/vuetify/sizes-v2' as sizes-v2;
+@use '/src/styles/vuetify/spacing-v2' as spacing-v2;
+@use '/src/styles/vuetify/typography-v2' as typography-v2;
+
+.rc-ses-radio-v2 {
+  $radio-size: sizes-v2.rc-size-v2('radio-size-v2');
+  $radio-container-size: sizes-v2.rc-size-v2('size-24-v2');
+  $radio-dot-size: sizes-v2.rc-size-v2('radio-dot-size-v2');
+  $hover-ring: 0 0 0 #{borders-v2.rc-stroke-v2('stroke-4-v2')} rgba(var(--v-theme-cyan-400-v2), 0.2);
+  $error-hover-ring: 0 0 0 #{borders-v2.rc-stroke-v2('stroke-4-v2')} rgba(var(--v-theme-red-600-v2), 0.2);
+
+  &.v-selection-control,
+  &.v-radio,
+  &--decorative {
+    flex: 0 0 auto;
+    min-height: $radio-container-size !important;
+    align-items: flex-start;
+    gap: 0;
+    padding-block: spacing-v2.rc-spacing-v2('spacing-8-v2');
+    opacity: 1;
+  }
+
+  &--decorative {
+    display: flex;
+    pointer-events: none;
+  }
+
+  .v-selection-control__wrapper {
+    box-sizing: border-box;
+    display: flex;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+    width: $radio-container-size;
+    height: $radio-container-size;
+    margin: 0;
+    padding: spacing-v2.rc-spacing-v2('spacing-2-v2');
+  }
+
+  .v-selection-control__input {
+    position: relative;
+    box-sizing: border-box;
+    width: $radio-size;
+    height: $radio-size;
+    border: borders-v2.rc-stroke-v2('stroke-2-v2') solid
+      rgb(var(--v-theme-neutral-500-v2));
+    border-radius: borders-v2.rc-radius-v2('radius-full-v2');
+    background-color: rgb(var(--v-theme-surface-base-v2));
+    transition:
+      background-color 0.15s ease,
+      border-color 0.15s ease,
+      box-shadow 0.15s ease;
+
+    &::before {
+      opacity: 0 !important;
+    }
+
+    .v-icon {
+      color: transparent;
+      opacity: 0;
+    }
+  }
+
+  .v-label {
+    @include typography-v2.rc-typography-v2('body-large-v2');
+
+    opacity: 1;
+    padding-inline-start: spacing-v2.rc-spacing-v2('spacing-8-v2');
+    color: rgb(var(--v-theme-text-default-v2));
+  }
+
+  &.rc-ses-radio-v2--checked .v-selection-control__input {
+    border-width: borders-v2.rc-stroke-v2('stroke-1-v2');
+    border-color: rgb(var(--v-theme-cyan-500-v2));
+    background-color: rgb(var(--v-theme-cyan-500-v2));
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: $radio-dot-size;
+      height: $radio-dot-size;
+      border-radius: borders-v2.rc-radius-v2('radius-full-v2');
+      background-color: rgb(var(--v-theme-text-inverse-v2));
+      transform: translate(-50%, -50%);
+    }
+  }
+
+  &:hover:not(.v-selection-control--disabled):not(.rc-ses-radio-v2--error):not(
+      .v-selection-control--focus-visible
+    )
+    .v-selection-control__input {
+    border-color: rgb(var(--v-theme-cyan-500-v2));
+    box-shadow: $hover-ring;
+  }
+
+  &.v-selection-control--focus-visible .v-selection-control__input {
+    box-shadow: none;
+    outline: borders-v2.rc-stroke-v2('border-width-focus-v2') solid
+      rgb(var(--v-theme-border-focus-actual-v2));
+    outline-offset: borders-v2.rc-stroke-v2('stroke-2-v2');
+  }
+
+  &.rc-ses-radio-v2--error {
+    .v-selection-control__input {
+      border-color: rgb(var(--v-theme-red-500-v2));
+    }
+
+    &.rc-ses-radio-v2--checked .v-selection-control__input {
+      border-color: rgb(var(--v-theme-red-500-v2));
+      background-color: rgb(var(--v-theme-red-500-v2));
+    }
+
+    &:hover:not(.v-selection-control--disabled):not(.v-selection-control--focus-visible)
+      .v-selection-control__input {
+      border-color: rgb(var(--v-theme-red-500-v2));
+      box-shadow: $error-hover-ring;
+    }
+  }
+
+  &.v-selection-control--disabled,
+  &.rc-ses-radio-v2--disabled {
+    opacity: 1 !important;
+
+    .v-label {
+      color: rgb(var(--v-theme-text-secondary-v2));
+    }
+
+    .v-selection-control__input {
+      border-width: borders-v2.rc-stroke-v2('stroke-2-v2');
+      border-color: rgb(var(--v-theme-neutral-500-v2));
+      background-color: rgb(var(--v-theme-neutral-200-v2));
+      box-shadow: none;
+      opacity: 1 !important;
+
+      &::after {
+        display: none;
+      }
+    }
+
+    &.rc-ses-radio-v2--checked .v-selection-control__input {
+      border-color: rgb(var(--v-theme-neutral-500-v2));
+      background-color: rgb(var(--v-theme-neutral-500-v2));
+
+      &::after {
+        display: block;
+        background-color: rgb(var(--v-theme-text-inverse-v2));
+      }
+    }
+  }
+
+  &--loading {
+    display: inline-flex;
+    align-items: flex-start;
+    gap: spacing-v2.rc-spacing-v2('spacing-8-v2');
+    padding-block: spacing-v2.rc-spacing-v2('spacing-8-v2');
+    cursor: default;
+    pointer-events: none;
+  }
+
+  &__skeleton-control {
+    box-sizing: border-box;
+    display: block;
+    flex: none;
+    width: $radio-size;
+    height: $radio-size;
+    margin: spacing-v2.rc-spacing-v2('spacing-2-v2');
+    border-radius: borders-v2.rc-radius-v2('radius-full-v2');
+    background-color: rgb(var(--v-theme-neutral-100-v2));
+  }
+
+  &__skeleton-label {
+    display: block;
+    flex: none;
+    width: 108px;
+    height: sizes-v2.rc-size-v2('size-16-v2');
+    margin-block: spacing-v2.rc-spacing-v2('spacing-4-v2');
+    border-radius: borders-v2.rc-radius-v2('radius-4-v2');
+    background: linear-gradient(
+        90deg,
+        rgba(var(--v-theme-neutral-200-v2), 0) 0%,
+        rgb(var(--v-theme-neutral-200-v2)) 70.19%,
+        rgba(var(--v-theme-neutral-200-v2), 0) 100%
+      ),
+      rgb(var(--v-theme-neutral-100-v2));
+    background-size: 200% 100%;
+    animation: rc-ses-radio-v2-skeleton 1.4s ease infinite;
+  }
+}
+
+@keyframes rc-ses-radio-v2-skeleton {
+  0% {
+    background-position: 100% 0;
+  }
+
+  100% {
+    background-position: -100% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rc-ses-radio-v2 .v-selection-control__input {
+    transition: none;
+  }
+
+  .rc-ses-radio-v2__skeleton-label {
+    animation: none;
+  }
+}

--- a/src/components/common/inputs/Radios/RadioV2/types.ts
+++ b/src/components/common/inputs/Radios/RadioV2/types.ts
@@ -1,0 +1,9 @@
+export type RadioProps = {
+  value: string | number | boolean
+  label?: string
+  showLabel?: boolean
+  disabled?: boolean
+  loading?: boolean
+  decorative?: boolean
+  accessibleLabel?: string
+}

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -33,6 +33,9 @@ import RcSesPhoneField from '@/components/common/inputs/PhoneField/RcSesPhoneFie
 import RcSesRadioButtonsField from '@/components/common/inputs/RadioButtonsField/RcSesRadioButtonsField.vue'
 import RcSesRadio from '@/components/common/inputs/Radios/Radio/RcSesRadio.vue'
 import RcSesRadioField from '@/components/common/inputs/Radios/RadioFields/RcSesRadioField.vue'
+import RcSesRadioGroupV2 from '@/components/common/inputs/Radios/RadioGroupV2/RcSesRadioGroupV2.vue'
+import RcSesRadioSelectableAreaV2 from '@/components/common/inputs/Radios/RadioSelectableAreaV2/RcSesRadioSelectableAreaV2.vue'
+import RcSesRadioV2 from '@/components/common/inputs/Radios/RadioV2/RcSesRadioV2.vue'
 import RcSesSearchField from '@/components/common/inputs/SearchField/RcSesSearchField.vue'
 import RcSesSearchableArea from '@/components/common/inputs/SearchableArea/RcSesSearchableArea.vue'
 import RcSesSearchableField from '@/components/common/inputs/SearchableField/RcSesSearchableField.vue'
@@ -117,6 +120,9 @@ export function createRcSesComponents(options: object = {}): Plugin<[]> {
       .component('RcSesRadio', RcSesRadio)
       .component('RcSesRadioField', RcSesRadioField)
       .component('RcSesRadioButtonsField', RcSesRadioButtonsField)
+      .component('RcSesRadioGroupV2', RcSesRadioGroupV2)
+      .component('RcSesRadioV2', RcSesRadioV2)
+      .component('RcSesRadioSelectableAreaV2', RcSesRadioSelectableAreaV2)
 
     app
       .component('RcSesSearchableArea', RcSesSearchableArea)
@@ -163,6 +169,7 @@ export {
 
 export { RcSesAlert, RcSesButton }
 export { RcSesBadgeV2, RcSesButtonV2, RcSesToggleV2 }
+export { RcSesRadioGroupV2, RcSesRadioV2, RcSesRadioSelectableAreaV2 }
 export { RcSesImageAndTextV2, RcSesInlineAlertV2, RcSesStepperV2 }
 export { RcSesLoaderV2, RcSesFullPageLoaderV2 }
 export { RcSesModalV2, RcSesBackdropV2 }

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -49,6 +49,10 @@ const i18n = () => {
             close: 'Uždaryti',
           },
 
+          RcSesRadioV2: {
+            loading: 'Kraunama...',
+          },
+
           RcSesStepperV2: {
             back: 'Grįžti',
             completedStep: 'Užbaigta: {{step}}',
@@ -121,6 +125,10 @@ const i18n = () => {
 
           RcSesInlineAlertV2: {
             close: 'Close',
+          },
+
+          RcSesRadioV2: {
+            loading: 'Loading...',
           },
 
           RcSesStepperV2: {

--- a/src/stories/components v2/Radio/Radio.stories.ts
+++ b/src/stories/components v2/Radio/Radio.stories.ts
@@ -1,0 +1,119 @@
+import type { Meta, StoryFn } from '@storybook/vue3'
+import { ref } from 'vue'
+
+import RcSesRadioGroupV2 from '@/components/common/inputs/Radios/RadioGroupV2/RcSesRadioGroupV2.vue'
+import RcSesRadioV2 from '@/components/common/inputs/Radios/RadioV2/RcSesRadioV2.vue'
+import type { RadioProps } from '@/components/common/inputs/Radios/RadioV2/types'
+
+const meta: Meta<typeof RcSesRadioV2> = {
+  title: 'componentsV2/Radio',
+  component: RcSesRadioV2,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Visible radio label',
+    },
+    showLabel: {
+      control: 'boolean',
+      description: 'Toggle the visible label',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    loading: {
+      control: 'boolean',
+    },
+    accessibleLabel: {
+      control: 'text',
+    },
+    value: {
+      control: 'text',
+      description: 'Option value within RcSesRadioGroupV2',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryFn<typeof RcSesRadioV2>
+
+const radioDefaultArgs: Partial<RadioProps> = {
+  label: 'Radio text',
+  showLabel: true,
+  disabled: false,
+  loading: false,
+  value: 'a',
+}
+
+export const Default: Story = (args) => ({
+  components: { RcSesRadioGroupV2, RcSesRadioV2 },
+  setup() {
+    const value = ref<string | null>(null)
+
+    return { args, value }
+  },
+  template: `
+    <RcSesRadioGroupV2 v-model="value" accessible-label="Radio">
+      <RcSesRadioV2 v-bind="args" />
+    </RcSesRadioGroupV2>
+  `,
+})
+Default.args = radioDefaultArgs as Meta<typeof RcSesRadioV2>['args']
+
+export const States: Story = () => ({
+  components: { RcSesRadioGroupV2, RcSesRadioV2 },
+  setup() {
+    return {
+      rest: ref<string | null>(null),
+      selected: ref('selected'),
+      disabled: ref<string | null>(null),
+      disabledSelected: ref('y'),
+      error: ref<string | null>(null),
+      errorSelected: ref('e2'),
+    }
+  },
+  template: `
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <RcSesRadioGroupV2 v-model="rest" accessible-label="Unselected">
+        <RcSesRadioV2 value="unselected" label="Unselected" />
+      </RcSesRadioGroupV2>
+
+      <RcSesRadioGroupV2 v-model="selected" accessible-label="Selected">
+        <RcSesRadioV2 value="selected" label="Selected" />
+      </RcSesRadioGroupV2>
+
+      <RcSesRadioGroupV2 v-model="disabled" accessible-label="Disabled" disabled>
+        <RcSesRadioV2 value="x" label="Disabled" />
+      </RcSesRadioGroupV2>
+
+      <RcSesRadioGroupV2
+        v-model="disabledSelected"
+        accessible-label="Disabled selected"
+        disabled
+      >
+        <RcSesRadioV2 value="y" label="Disabled selected" />
+      </RcSesRadioGroupV2>
+
+      <RcSesRadioGroupV2
+        v-model="error"
+        accessible-label="Error"
+        error="Required field"
+      >
+        <RcSesRadioV2 value="e1" label="Error" />
+      </RcSesRadioGroupV2>
+
+      <RcSesRadioGroupV2
+        v-model="errorSelected"
+        accessible-label="Error selected"
+        error="Required field"
+      >
+        <RcSesRadioV2 value="e2" label="Error selected" />
+      </RcSesRadioGroupV2>
+
+      <RcSesRadioGroupV2 accessible-label="Loading">
+        <RcSesRadioV2 value="loading" label="Loading" loading />
+      </RcSesRadioGroupV2>
+    </div>
+  `,
+})

--- a/src/stories/components v2/RadioGroup/RadioGroup.stories.ts
+++ b/src/stories/components v2/RadioGroup/RadioGroup.stories.ts
@@ -1,0 +1,104 @@
+import type { Meta, StoryFn } from '@storybook/vue3'
+import { ref } from 'vue'
+
+import RcSesRadioGroupV2 from '@/components/common/inputs/Radios/RadioGroupV2/RcSesRadioGroupV2.vue'
+import type { RadioGroupProps } from '@/components/common/inputs/Radios/RadioGroupV2/types'
+import RcSesRadioV2 from '@/components/common/inputs/Radios/RadioV2/RcSesRadioV2.vue'
+
+const meta: Meta<typeof RcSesRadioGroupV2> = {
+  title: 'componentsV2/RadioGroup',
+  component: RcSesRadioGroupV2,
+  tags: ['autodocs'],
+  argTypes: {
+    accessibleLabel: {
+      control: 'text',
+      description: 'Screen reader name for the radiogroup',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    error: {
+      control: 'text',
+      description: 'Error state (boolean or message string)',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryFn<typeof RcSesRadioGroupV2>
+
+const defaultArgs: Partial<RadioGroupProps> = {
+  accessibleLabel: 'Select an option',
+  disabled: false,
+  error: false,
+}
+
+export const Default: Story = (args) => ({
+  components: { RcSesRadioGroupV2, RcSesRadioV2 },
+  setup() {
+    const value = ref<string | null>(null)
+
+    return { args, value }
+  },
+  template: `
+    <RcSesRadioGroupV2 v-model="value" v-bind="args">
+      <RcSesRadioV2 value="a" label="Radio text" />
+      <RcSesRadioV2 value="b" label="Selected option" />
+    </RcSesRadioGroupV2>
+  `,
+})
+Default.args = defaultArgs as Meta<typeof RcSesRadioGroupV2>['args']
+
+export const States: Story = () => ({
+  components: { RcSesRadioGroupV2, RcSesRadioV2 },
+  setup() {
+    return {
+      rest: ref<string | null>(null),
+      selected: ref('b'),
+      disabled: ref('b'),
+      error: ref<string | null>(null),
+      errorSelected: ref('b'),
+    }
+  },
+  template: `
+    <div style="display: flex; flex-direction: column; gap: 24px;">
+      <RcSesRadioGroupV2 v-model="rest" accessible-label="Unselected">
+        <RcSesRadioV2 value="a" label="Option A" />
+        <RcSesRadioV2 value="b" label="Option B" />
+      </RcSesRadioGroupV2>
+
+      <RcSesRadioGroupV2 v-model="selected" accessible-label="Selected">
+        <RcSesRadioV2 value="a" label="Option A" />
+        <RcSesRadioV2 value="b" label="Option B" />
+      </RcSesRadioGroupV2>
+
+      <RcSesRadioGroupV2 v-model="disabled" accessible-label="Disabled" disabled>
+        <RcSesRadioV2 value="a" label="Option A" />
+        <RcSesRadioV2 value="b" label="Option B" />
+      </RcSesRadioGroupV2>
+
+      <RcSesRadioGroupV2
+        v-model="error"
+        accessible-label="Error"
+        error="Required field"
+      >
+        <RcSesRadioV2 value="a" label="Option A" />
+        <RcSesRadioV2 value="b" label="Option B" />
+      </RcSesRadioGroupV2>
+
+      <RcSesRadioGroupV2
+        v-model="errorSelected"
+        accessible-label="Error selected"
+        error="Required field"
+      >
+        <RcSesRadioV2 value="a" label="Option A" />
+        <RcSesRadioV2 value="b" label="Option B" />
+      </RcSesRadioGroupV2>
+
+      <RcSesRadioGroupV2 accessible-label="Loading">
+        <RcSesRadioV2 value="a" label="Loading" loading />
+      </RcSesRadioGroupV2>
+    </div>
+  `,
+})

--- a/src/stories/components v2/RadioSelectableArea/RadioSelectableArea.stories.ts
+++ b/src/stories/components v2/RadioSelectableArea/RadioSelectableArea.stories.ts
@@ -1,0 +1,149 @@
+import type { Meta, StoryFn } from '@storybook/vue3'
+import { ref } from 'vue'
+
+import RcSesRadioGroupV2 from '@/components/common/inputs/Radios/RadioGroupV2/RcSesRadioGroupV2.vue'
+import RcSesRadioSelectableAreaV2 from '@/components/common/inputs/Radios/RadioSelectableAreaV2/RcSesRadioSelectableAreaV2.vue'
+import type { RadioSelectableAreaProps } from '@/components/common/inputs/Radios/RadioSelectableAreaV2/types'
+
+const meta: Meta<typeof RcSesRadioSelectableAreaV2> = {
+  title: 'componentsV2/RadioSelectableArea',
+  component: RcSesRadioSelectableAreaV2,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Optional heading (Heading=true in Figma)',
+    },
+    description: {
+      control: 'text',
+    },
+    trailing: {
+      control: 'text',
+      description: 'Trailing value, e.g. price',
+    },
+    value: {
+      control: 'text',
+      description: 'Option value within RcSesRadioGroupV2',
+    },
+    disabled: { control: 'boolean' },
+    loading: { control: 'boolean' },
+  },
+}
+
+export default meta
+
+type Story = StoryFn<typeof RcSesRadioSelectableAreaV2>
+
+const defaultArgs: Partial<RadioSelectableAreaProps> = {
+  title: 'Title',
+  description: 'Description text placed here.',
+  trailing: '00,00 €',
+  value: 'option-a',
+  disabled: false,
+  loading: false,
+}
+
+export const WithHeading: Story = (args) => ({
+  components: { RcSesRadioGroupV2, RcSesRadioSelectableAreaV2 },
+  setup() {
+    const value = ref<string | null>(null)
+
+    return { args, value }
+  },
+  template: `
+    <RcSesRadioGroupV2 v-model="value" accessible-label="Payment" style="max-width: 436px;">
+      <RcSesRadioSelectableAreaV2 v-bind="args" />
+      <RcSesRadioSelectableAreaV2
+        value="option-b"
+        title="Title B"
+        description="Description text placed here."
+        trailing="12,00 €"
+      />
+    </RcSesRadioGroupV2>
+  `,
+})
+WithHeading.args = defaultArgs as Meta<typeof RcSesRadioSelectableAreaV2>['args']
+
+export const DescriptionOnly: Story = () => ({
+  components: { RcSesRadioGroupV2, RcSesRadioSelectableAreaV2 },
+  setup() {
+    const value = ref('option-a')
+
+    return { value }
+  },
+  template: `
+    <RcSesRadioGroupV2 v-model="value" accessible-label="Options" style="max-width: 436px;">
+      <RcSesRadioSelectableAreaV2
+        value="option-a"
+        description="Description text placed here."
+        trailing="00,00 €"
+      />
+      <RcSesRadioSelectableAreaV2
+        value="option-b"
+        description="Another option."
+        trailing="05,00 €"
+      />
+    </RcSesRadioGroupV2>
+  `,
+})
+
+export const States: Story = () => ({
+  components: { RcSesRadioGroupV2, RcSesRadioSelectableAreaV2 },
+  setup() {
+    return {
+      rest: ref<string | null>(null),
+      selected: ref('selected'),
+      disabled: ref<string | null>(null),
+      error: ref<string | null>(null),
+    }
+  },
+  template: `
+    <div style="display: flex; flex-direction: column; gap: 12px; max-width: 436px;">
+      <RcSesRadioGroupV2 v-model="rest" accessible-label="Rest">
+        <RcSesRadioSelectableAreaV2
+          value="rest"
+          title="Title"
+          description="Description text placed here."
+          trailing="00,00 €"
+        />
+      </RcSesRadioGroupV2>
+
+      <RcSesRadioGroupV2 v-model="selected" accessible-label="Selected">
+        <RcSesRadioSelectableAreaV2
+          value="selected"
+          title="Title"
+          description="Description text placed here."
+          trailing="00,00 €"
+        />
+      </RcSesRadioGroupV2>
+
+      <RcSesRadioGroupV2 v-model="disabled" accessible-label="Disabled" disabled>
+        <RcSesRadioSelectableAreaV2
+          value="disabled"
+          title="Title"
+          description="Description text placed here."
+          trailing="00,00 €"
+        />
+      </RcSesRadioGroupV2>
+
+      <RcSesRadioGroupV2 v-model="error" accessible-label="Error" error>
+        <RcSesRadioSelectableAreaV2
+          value="error"
+          title="Title"
+          description="Description text placed here."
+          trailing="00,00 €"
+        />
+      </RcSesRadioGroupV2>
+
+      <RcSesRadioGroupV2 accessible-label="Loading">
+        <RcSesRadioSelectableAreaV2
+          value="loading"
+          title="Title"
+          description="Description text placed here."
+          trailing="00,00 €"
+          loading
+        />
+      </RcSesRadioGroupV2>
+    </div>
+  `,
+})

--- a/src/styles/vuetify/_sizes-v2.scss
+++ b/src/styles/vuetify/_sizes-v2.scss
@@ -31,6 +31,11 @@ $rc-size-v2-semantic: (
   'toggle-track-width-v2': 'size-36-v2',
   'toggle-track-height-v2': 'size-20-v2',
   'toggle-thumb-size-v2': 'size-16-v2',
+  // Radio / Checkbox
+  'radio-size-v2': 'size-20-v2',
+  'radio-dot-size-v2': 'size-8-v2',
+  'checkbox-size-v2': 'size-20-v2',
+  'checkbox-icon-size-v2': 'size-16-v2',
 );
 
 @function rc-size-v2($token) {


### PR DESCRIPTION
## 🔗 Task

https://jira.registrucentras.lt/jira/browse/IRM-5287
https://jira.registrucentras.lt/jira/browse/IRM-5298

@tomas562  @saukaite 

## 🧾 Summary

Adds RcSesRadioGroupV2 — v2 radio group with v-model, group-level error / disabled, and accessibleLabel (radiogroup + fieldset). Provides selection context to child options via provide/inject; error helper uses body-caption-v2 and error-border-v2, indented under option labels (aligned with Checkbox V2). Includes Storybook, tests, and library export.

Adds RcSesRadioV2 — v2 radio option on v-radio with Figma states (rest, hover, focus, disabled, error, loading), optional label (showLabel), accessibleLabel, and value for use inside RcSesRadioGroupV2. Styling uses v2 tokens (circular control, inner dot). Includes Storybook, tests, i18n, and library export.

Adds RcSesRadioSelectableAreaV2 — v2 clickable row (decorative radio + optional title/description + trailing) with Figma area states and description-only layout. Wraps RcSesRadioV2 (decorative); single role="radio" on the area for a11y. Styling uses v2 tokens. Includes Storybook, tests, and library export.

## 📸 Screenshots

<img width="1035" height="620" alt="image" src="https://github.com/user-attachments/assets/e41e4561-c8b8-40ca-8494-9592e75fb7cf" />

<img width="1052" height="871" alt="image" src="https://github.com/user-attachments/assets/b551d031-3e70-4eaf-aafd-06261e1adef7" />


## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [x] UI matches approved design (Figma)
* [x] Accessibility reviewed (keyboard navigation, labels, semantics)
