### PR TITLE
IRM-5294 (AdvancedListV2, AdvancedListItemV2)

### DIFF
--- a/src/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.test.ts
+++ b/src/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.test.ts
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
 import { describe, expect, it } from 'vitest'
 
+import RcSesAdvancedListV2 from '@/components/common/AdvancedListV2/RcSesAdvancedListV2.vue'
+
 import RcSesAdvancedListItemV2 from './RcSesAdvancedListItemV2.vue'
 
 describe('RcSesAdvancedListItemV2', () => {
@@ -62,8 +64,28 @@ describe('RcSesAdvancedListItemV2', () => {
     expect(item).toHaveClass('rc-ses-advanced-list-item-v2--error')
   })
 
-  it('sets option semantics when selectable', () => {
-    renderItem({ selectable: true, selected: true })
+  it('does not set option role when selectable outside a listbox', () => {
+    const { container } = renderItem({ selectable: true, selected: true })
+
+    expect(screen.queryByRole('option')).not.toBeInTheDocument()
+    expect(container.querySelector('.rc-ses-advanced-list-item-v2')).toHaveAttribute(
+      'tabindex',
+      '0',
+    )
+    expect(container.querySelector('.rc-ses-advanced-list-item-v2')).not.toHaveAttribute(
+      'aria-selected',
+    )
+  })
+
+  it('sets option semantics when selectable inside a listbox', () => {
+    render({
+      components: { RcSesAdvancedListV2, RcSesAdvancedListItemV2 },
+      template: `
+        <RcSesAdvancedListV2 listbox accessible-label="Options">
+          <RcSesAdvancedListItemV2 title="Jonas Jonaitis" selectable selected />
+        </RcSesAdvancedListV2>
+      `,
+    })
 
     const option = screen.getByRole('option')
     expect(option).toHaveAttribute('aria-selected', 'true')
@@ -71,17 +93,17 @@ describe('RcSesAdvancedListItemV2', () => {
   })
 
   it('emits select when selectable item is clicked', async () => {
-    const { emitted } = renderItem({ selectable: true })
+    const { emitted, container } = renderItem({ selectable: true })
 
-    await fireEvent.click(screen.getByRole('option'))
+    await fireEvent.click(container.querySelector('.rc-ses-advanced-list-item-v2')!)
 
     expect(emitted().select).toHaveLength(1)
   })
 
   it('does not emit select when disabled', async () => {
-    const { emitted } = renderItem({ selectable: true, disabled: true })
+    const { emitted, container } = renderItem({ selectable: true, disabled: true })
 
-    await fireEvent.click(screen.getByRole('option'))
+    await fireEvent.click(container.querySelector('.rc-ses-advanced-list-item-v2')!)
 
     expect(emitted().select).toBeUndefined()
   })
@@ -97,10 +119,25 @@ describe('RcSesAdvancedListItemV2', () => {
     expect(emitted().select).toBeUndefined()
   })
 
-  it('emits select via keyboard Enter', async () => {
-    const { emitted } = renderItem({ selectable: true })
+  it('does not emit select from trailing keydown Enter/Space', async () => {
+    const { emitted } = renderItem(
+      { selectable: true, showTrailing: true },
+      { trailing: '<button type="button">Pašalinti</button>' },
+    )
 
-    await fireEvent.keyDown(screen.getByRole('option'), { key: 'Enter' })
+    const button = screen.getByRole('button', { name: 'Pašalinti' })
+
+    await fireEvent.keyDown(button, { key: 'Enter' })
+    await fireEvent.keyDown(button, { key: ' ' })
+
+    expect(emitted().select).toBeUndefined()
+  })
+
+  it('emits select via keyboard Enter on the item itself', async () => {
+    const { emitted, container } = renderItem({ selectable: true })
+    const item = container.querySelector('.rc-ses-advanced-list-item-v2')!
+
+    await fireEvent.keyDown(item, { key: 'Enter' })
 
     expect(emitted().select).toHaveLength(1)
   })

--- a/src/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.test.ts
+++ b/src/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.test.ts
@@ -1,0 +1,173 @@
+import { fireEvent, render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+import RcSesAdvancedListItemV2 from './RcSesAdvancedListItemV2.vue'
+
+describe('RcSesAdvancedListItemV2', () => {
+  const renderItem = (
+    props: Record<string, unknown> = {},
+    slots: Record<string, string> = {},
+  ) =>
+    render(RcSesAdvancedListItemV2, {
+      props: {
+        title: 'Jonas Jonaitis',
+        ...props,
+      },
+      slots,
+    })
+
+  it('renders title and subtitle', () => {
+    renderItem({ subtitle: 'a.k. 3850********', showSubtitle: true })
+
+    expect(screen.getByText('Jonas Jonaitis')).toHaveClass(
+      'rc-ses-advanced-list-item-v2__title',
+    )
+    expect(screen.getByText('a.k. 3850********')).toHaveClass(
+      'rc-ses-advanced-list-item-v2__subtitle',
+    )
+  })
+
+  it('hides subtitle when showSubtitle is false', () => {
+    renderItem({ subtitle: 'Hidden', showSubtitle: false })
+
+    expect(screen.queryByText('Hidden')).not.toBeInTheDocument()
+  })
+
+  it('applies card container class by default', () => {
+    const { container } = renderItem()
+
+    expect(container.querySelector('.rc-ses-advanced-list-item-v2')).toHaveClass(
+      'rc-ses-advanced-list-item-v2--card',
+    )
+  })
+
+  it('applies row container class', () => {
+    const { container } = renderItem({ container: 'row' })
+
+    expect(container.querySelector('.rc-ses-advanced-list-item-v2')).toHaveClass(
+      'rc-ses-advanced-list-item-v2--row',
+    )
+  })
+
+  it('applies selected, disabled and error modifiers', () => {
+    const { container } = renderItem({
+      selected: true,
+      disabled: true,
+      error: true,
+    })
+
+    const item = container.querySelector('.rc-ses-advanced-list-item-v2')
+    expect(item).toHaveClass('rc-ses-advanced-list-item-v2--selected')
+    expect(item).toHaveClass('rc-ses-advanced-list-item-v2--disabled')
+    expect(item).toHaveClass('rc-ses-advanced-list-item-v2--error')
+  })
+
+  it('sets option semantics when selectable', () => {
+    renderItem({ selectable: true, selected: true })
+
+    const option = screen.getByRole('option')
+    expect(option).toHaveAttribute('aria-selected', 'true')
+    expect(option).toHaveAttribute('tabindex', '0')
+  })
+
+  it('emits select when selectable item is clicked', async () => {
+    const { emitted } = renderItem({ selectable: true })
+
+    await fireEvent.click(screen.getByRole('option'))
+
+    expect(emitted().select).toHaveLength(1)
+  })
+
+  it('does not emit select when disabled', async () => {
+    const { emitted } = renderItem({ selectable: true, disabled: true })
+
+    await fireEvent.click(screen.getByRole('option'))
+
+    expect(emitted().select).toBeUndefined()
+  })
+
+  it('does not emit select from trailing actions', async () => {
+    const { emitted } = renderItem(
+      { selectable: true, showTrailing: true },
+      { trailing: '<button type="button">Pašalinti</button>' },
+    )
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Pašalinti' }))
+
+    expect(emitted().select).toBeUndefined()
+  })
+
+  it('emits select via keyboard Enter', async () => {
+    const { emitted } = renderItem({ selectable: true })
+
+    await fireEvent.keyDown(screen.getByRole('option'), { key: 'Enter' })
+
+    expect(emitted().select).toHaveLength(1)
+  })
+
+  it('renders leading, trailing, meta, badge and expanded slots', () => {
+    renderItem(
+      {
+        showLeading: true,
+        showTrailing: true,
+        showMeta: true,
+        showBadge: true,
+        showExpanded: true,
+        showLeadingMedia: true,
+      },
+      {
+        leading: '<span data-testid="leading">L</span>',
+        'leading-media': '<span data-testid="leading-media">M</span>',
+        trailing: '<span data-testid="trailing">T</span>',
+        meta: '<span data-testid="meta">Meta</span>',
+        badge: '<span data-testid="badge">Badge</span>',
+        expanded: '<span data-testid="expanded">More</span>',
+      },
+    )
+
+    expect(screen.getByTestId('leading')).toBeInTheDocument()
+    expect(screen.getByTestId('leading-media')).toBeInTheDocument()
+    expect(screen.getByTestId('trailing')).toBeInTheDocument()
+    expect(screen.getByTestId('meta')).toBeInTheDocument()
+    expect(screen.getByTestId('badge')).toBeInTheDocument()
+    expect(screen.getByTestId('expanded')).toBeInTheDocument()
+  })
+
+  it('hides leading when showLeading is false', () => {
+    renderItem(
+      { showLeading: false },
+      { leading: '<span data-testid="leading">L</span>' },
+    )
+
+    expect(screen.queryByTestId('leading')).not.toBeInTheDocument()
+  })
+
+  it('does not render leading-media when showLeadingMedia is false by default', () => {
+    renderItem({}, { 'leading-media': '<span data-testid="leading-media">M</span>' })
+
+    expect(screen.queryByTestId('leading-media')).not.toBeInTheDocument()
+  })
+
+  it('does not render meta, badge or expanded when show flags are false by default', () => {
+    renderItem(
+      {},
+      {
+        meta: '<span data-testid="meta">Meta</span>',
+        badge: '<span data-testid="badge">Badge</span>',
+        expanded: '<span data-testid="expanded">More</span>',
+      },
+    )
+
+    expect(screen.queryByTestId('meta')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('badge')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('expanded')).not.toBeInTheDocument()
+  })
+
+  it('applies nesting level via CSS variable', () => {
+    const { container } = renderItem({ level: 2 })
+
+    expect(container.querySelector('.rc-ses-advanced-list-item-v2')).toHaveStyle({
+      '--rc-ses-list-item-level': '2',
+    })
+  })
+})

--- a/src/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.vue
+++ b/src/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.vue
@@ -1,0 +1,134 @@
+<template>
+  <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -- tabindex bound when selectable: 0 enabled / -1 disabled -->
+  <li
+    :class="rootClasses"
+    :style="rootStyle"
+    :role="props.selectable ? 'option' : undefined"
+    :tabindex="tabIndex"
+    :aria-selected="props.selectable ? props.selected : undefined"
+    :aria-disabled="props.disabled || undefined"
+    @click="handleSelect"
+    @keydown.enter.prevent="handleSelect"
+    @keydown.space.prevent="handleSelect"
+  >
+    <div class="rc-ses-advanced-list-item-v2__body">
+      <div
+        v-if="props.showLeading && $slots.leading"
+        class="rc-ses-advanced-list-item-v2__leading"
+      >
+        <slot name="leading" />
+      </div>
+
+      <div
+        v-if="props.showLeadingMedia && $slots['leading-media']"
+        class="rc-ses-advanced-list-item-v2__leading-media"
+        aria-hidden="true"
+      >
+        <slot name="leading-media" />
+      </div>
+
+      <div class="rc-ses-advanced-list-item-v2__content">
+        <div class="rc-ses-advanced-list-item-v2__title-row">
+          <p class="rc-ses-advanced-list-item-v2__title">
+            <slot name="title">{{ props.title }}</slot>
+          </p>
+          <div
+            v-if="props.showBadge && $slots.badge"
+            class="rc-ses-advanced-list-item-v2__badge"
+          >
+            <slot name="badge" />
+          </div>
+        </div>
+
+        <p
+          v-if="props.showSubtitle && props.subtitle"
+          class="rc-ses-advanced-list-item-v2__subtitle"
+        >
+          {{ props.subtitle }}
+        </p>
+
+        <div
+          v-if="props.showMeta && $slots.meta"
+          class="rc-ses-advanced-list-item-v2__meta"
+        >
+          <slot name="meta" />
+        </div>
+
+        <div v-if="$slots.default" class="rc-ses-advanced-list-item-v2__description">
+          <slot />
+        </div>
+      </div>
+
+      <div
+        v-if="props.showTrailing && $slots.trailing"
+        class="rc-ses-advanced-list-item-v2__trailing"
+        @click.stop
+      >
+        <slot name="trailing" />
+      </div>
+    </div>
+
+    <div
+      v-if="props.showExpanded && $slots.expanded"
+      class="rc-ses-advanced-list-item-v2__expanded"
+      @click.stop
+    >
+      <slot name="expanded" />
+    </div>
+  </li>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import advancedListItemV2Defaults from '@/components/common/AdvancedListItemV2/defaults'
+import type { AdvancedListItemProps } from '@/components/common/AdvancedListItemV2/types'
+
+import './style.scss'
+
+const props = withDefaults(
+  defineProps<AdvancedListItemProps>(),
+  advancedListItemV2Defaults,
+)
+
+const emit = defineEmits<{
+  select: []
+}>()
+
+const tabIndex = computed(() => {
+  if (!props.selectable) {
+    return undefined
+  }
+
+  return props.disabled ? -1 : 0
+})
+
+const rootClasses = computed(() => [
+  'rc-ses-advanced-list-item-v2',
+  `rc-ses-advanced-list-item-v2--${props.container}`,
+  {
+    'rc-ses-advanced-list-item-v2--selectable': props.selectable,
+    'rc-ses-advanced-list-item-v2--selected': props.selected,
+    'rc-ses-advanced-list-item-v2--disabled': props.disabled,
+    'rc-ses-advanced-list-item-v2--error': props.error,
+  },
+])
+
+const rootStyle = computed(() => {
+  if (!props.level) {
+    return undefined
+  }
+
+  return {
+    '--rc-ses-list-item-level': String(props.level),
+  }
+})
+
+const handleSelect = () => {
+  if (!props.selectable || props.disabled) {
+    return
+  }
+
+  emit('select')
+}
+</script>

--- a/src/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.vue
+++ b/src/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.vue
@@ -3,13 +3,13 @@
   <li
     :class="rootClasses"
     :style="rootStyle"
-    :role="props.selectable ? 'option' : undefined"
+    :role="isListboxOption ? 'option' : undefined"
     :tabindex="tabIndex"
-    :aria-selected="props.selectable ? props.selected : undefined"
+    :aria-selected="isListboxOption ? props.selected : undefined"
     :aria-disabled="props.disabled || undefined"
     @click="handleSelect"
-    @keydown.enter.prevent="handleSelect"
-    @keydown.space.prevent="handleSelect"
+    @keydown.enter.self.prevent="handleSelect"
+    @keydown.space.self.prevent="handleSelect"
   >
     <div class="rc-ses-advanced-list-item-v2__body">
       <div
@@ -63,6 +63,7 @@
         v-if="props.showTrailing && $slots.trailing"
         class="rc-ses-advanced-list-item-v2__trailing"
         @click.stop
+        @keydown.stop
       >
         <slot name="trailing" />
       </div>
@@ -72,6 +73,7 @@
       v-if="props.showExpanded && $slots.expanded"
       class="rc-ses-advanced-list-item-v2__expanded"
       @click.stop
+      @keydown.stop
     >
       <slot name="expanded" />
     </div>
@@ -79,8 +81,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, inject } from 'vue'
 
+import { advancedListV2Key } from '@/components/common/AdvancedListV2/context'
 import advancedListItemV2Defaults from '@/components/common/AdvancedListItemV2/defaults'
 import type { AdvancedListItemProps } from '@/components/common/AdvancedListItemV2/types'
 
@@ -94,6 +97,12 @@ const props = withDefaults(
 const emit = defineEmits<{
   select: []
 }>()
+
+const listContext = inject(advancedListV2Key, null)
+
+const isListboxOption = computed(
+  () => props.selectable && !!listContext?.isListbox.value,
+)
 
 const tabIndex = computed(() => {
   if (!props.selectable) {

--- a/src/components/common/AdvancedListItemV2/defaults.ts
+++ b/src/components/common/AdvancedListItemV2/defaults.ts
@@ -1,0 +1,28 @@
+import type {
+  AdvancedListItemContainer,
+  AdvancedListItemProps,
+} from '@/components/common/AdvancedListItemV2/types'
+
+export type AdvancedListItemDefaultsType = Required<
+  Omit<AdvancedListItemProps, 'title' | 'subtitle'>
+> & {
+  container: AdvancedListItemContainer
+}
+
+const advancedListItemV2Defaults = {
+  container: 'card',
+  showLeading: true,
+  showLeadingMedia: false,
+  showTrailing: true,
+  showSubtitle: true,
+  showMeta: false,
+  showBadge: false,
+  showExpanded: false,
+  level: 0,
+  selectable: false,
+  selected: false,
+  disabled: false,
+  error: false,
+} satisfies AdvancedListItemDefaultsType
+
+export default advancedListItemV2Defaults

--- a/src/components/common/AdvancedListItemV2/style.scss
+++ b/src/components/common/AdvancedListItemV2/style.scss
@@ -1,0 +1,225 @@
+@use '/src/styles/vuetify/borders-v2' as borders-v2;
+@use '/src/styles/vuetify/sizes-v2' as sizes-v2;
+@use '/src/styles/vuetify/spacing-v2' as spacing-v2;
+@use '/src/styles/vuetify/typography-v2' as typo-v2;
+
+.rc-ses-advanced-list-item-v2 {
+  --rc-ses-list-item-level: 0;
+
+  box-sizing: border-box;
+  color: rgb(var(--v-theme-text-default-v2));
+  list-style: none;
+  margin: 0;
+  margin-inline-start: calc(
+    var(--rc-ses-list-item-level) * #{spacing-v2.rc-spacing-v2('list-item-indent-v2')}
+  );
+  max-width: 100%;
+  min-width: 0;
+  width: calc(
+    100% - var(--rc-ses-list-item-level) * #{spacing-v2.rc-spacing-v2(
+        'list-item-indent-v2'
+      )}
+  );
+
+  &__body {
+    align-items: center;
+    box-sizing: border-box;
+    display: flex;
+    gap: spacing-v2.rc-spacing-v2('list-item-gap-v2');
+    max-width: 100%;
+    min-width: 0;
+    padding: spacing-v2.rc-spacing-v2('list-item-padding-y-v2')
+      spacing-v2.rc-spacing-v2('list-item-padding-x-v2');
+    width: 100%;
+  }
+
+  &__leading {
+    align-items: center;
+    align-self: center;
+    display: flex;
+    flex-direction: column;
+    flex-shrink: 0;
+    gap: spacing-v2.rc-spacing-v2('list-item-leading-gap-v2');
+    justify-content: center;
+    line-height: 0;
+  }
+
+  &__trailing {
+    align-items: center;
+    box-sizing: border-box;
+    display: flex;
+    flex: 0 1 auto;
+    flex-wrap: wrap;
+    gap: spacing-v2.rc-spacing-v2('list-item-trailing-gap-v2');
+    justify-content: flex-end;
+    max-width: 50%;
+    min-width: 0;
+
+    .rc-ses-price-display-v2 {
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-start;
+      max-width: 100%;
+      text-align: right;
+      width: auto;
+    }
+  }
+
+  &__leading-media {
+    align-items: center;
+    background-color: rgb(var(--v-theme-surface-muted-v2));
+    border: borders-v2.rc-stroke-v2('border-width-default-v2') solid
+      rgb(var(--v-theme-border-subtle-v2));
+    border-radius: borders-v2.rc-radius-v2('list-item-radius-v2');
+    box-sizing: border-box;
+    display: flex;
+    flex-shrink: 0;
+    height: sizes-v2.rc-size-v2('size-40-v2');
+    justify-content: center;
+    overflow: hidden;
+    width: sizes-v2.rc-size-v2('size-40-v2');
+
+    img,
+    svg {
+      display: block;
+      height: 100%;
+      object-fit: contain;
+      width: 100%;
+    }
+  }
+
+  &__content {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: spacing-v2.rc-spacing-v2('spacing-4-v2');
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  &__title-row {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: spacing-v2.rc-spacing-v2('spacing-8-v2');
+    min-width: 0;
+  }
+
+  &__title {
+    @include typo-v2.rc-typography-v2('body-large-v2');
+
+    align-items: baseline;
+    display: flex;
+    flex-wrap: wrap;
+    font-weight: 600;
+    gap: spacing-v2.rc-spacing-v2('spacing-8-v2');
+    line-height: 1.375rem;
+    margin: 0;
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  &__subtitle {
+    @include typo-v2.rc-typography-v2('body-small-v2');
+
+    color: rgb(var(--v-theme-text-secondary-v2));
+    margin: 0;
+    overflow-wrap: anywhere;
+  }
+
+  &__meta {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: spacing-v2.rc-spacing-v2('list-item-meta-gap-v2');
+  }
+
+  &__description {
+    @include typo-v2.rc-typography-v2('body-small-v2');
+
+    color: rgb(var(--v-theme-text-secondary-v2));
+  }
+
+  &__badge {
+    align-items: center;
+    display: flex;
+    flex-shrink: 0;
+  }
+
+  &__expanded {
+    background-color: rgb(var(--v-theme-surface-sunken-v2));
+    border-radius: borders-v2.rc-radius-v2('list-item-radius-v2');
+    box-sizing: border-box;
+    margin: 0 spacing-v2.rc-spacing-v2('list-item-padding-x-v2')
+      spacing-v2.rc-spacing-v2('list-item-padding-y-v2');
+    padding: spacing-v2.rc-spacing-v2('spacing-12-v2');
+  }
+
+  &--card {
+    background-color: rgb(var(--v-theme-surface-base-v2));
+    border: borders-v2.rc-stroke-v2('border-width-default-v2') solid
+      rgb(var(--v-theme-border-subtle-v2));
+    border-radius: borders-v2.rc-radius-v2('list-item-radius-v2');
+
+    &:hover:not(.rc-ses-advanced-list-item-v2--disabled):not(
+        .rc-ses-advanced-list-item-v2--selected
+      ):not(.rc-ses-advanced-list-item-v2--error) {
+      background-color: rgb(var(--v-theme-cyan-50-v2));
+    }
+
+    &:focus-within:not(.rc-ses-advanced-list-item-v2--disabled):not(
+        .rc-ses-advanced-list-item-v2--selected
+      ) {
+      border-color: rgb(var(--v-theme-border-focus-actual-v2));
+    }
+  }
+
+  &--row {
+    background-color: transparent;
+    border: none;
+    border-bottom: borders-v2.rc-stroke-v2('border-width-default-v2') solid
+      rgb(var(--v-theme-border-subtle-v2));
+    border-radius: 0;
+
+    &:hover:not(.rc-ses-advanced-list-item-v2--disabled):not(
+        .rc-ses-advanced-list-item-v2--selected
+      ):not(.rc-ses-advanced-list-item-v2--error) {
+      background-color: rgb(var(--v-theme-cyan-50-v2));
+    }
+
+    &:focus-within:not(.rc-ses-advanced-list-item-v2--disabled) {
+      outline: borders-v2.rc-stroke-v2('border-width-default-v2') solid
+        rgb(var(--v-theme-border-focus-actual-v2));
+      outline-offset: -1px;
+    }
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  &--selected {
+    background-color: rgb(var(--v-theme-cyan-50-v2));
+    border-color: rgb(var(--v-theme-border-focus-actual-v2));
+    // inset = visual 2px ring without expanding scrollWidth in Storybook Docs
+    box-shadow: inset 0 0 0 borders-v2.rc-stroke-v2('border-width-default-v2')
+      rgb(var(--v-theme-border-focus-actual-v2));
+  }
+
+  &--error {
+    border-color: rgb(var(--v-theme-destructive-bg-v2));
+  }
+
+  &--disabled {
+    opacity: 0.48;
+    pointer-events: none;
+  }
+
+  &--selectable {
+    cursor: pointer;
+
+    .rc-ses-advanced-list-item-v2__leading {
+      pointer-events: none;
+    }
+  }
+}

--- a/src/components/common/AdvancedListItemV2/types.ts
+++ b/src/components/common/AdvancedListItemV2/types.ts
@@ -14,7 +14,6 @@ export type AdvancedListItemProps = {
   showExpanded?: boolean
   /** Nesting depth for indented sub-items (0 = root) */
   level?: number
-  /** When true, sets role="option" + aria-selected for listbox patterns */
   selectable?: boolean
   selected?: boolean
   disabled?: boolean

--- a/src/components/common/AdvancedListItemV2/types.ts
+++ b/src/components/common/AdvancedListItemV2/types.ts
@@ -1,0 +1,22 @@
+export type AdvancedListItemContainer = 'card' | 'row'
+
+export type AdvancedListItemProps = {
+  /** Card = bordered tile; Row = divider list row */
+  container?: AdvancedListItemContainer
+  title: string
+  subtitle?: string
+  showLeading?: boolean
+  showLeadingMedia?: boolean
+  showTrailing?: boolean
+  showSubtitle?: boolean
+  showMeta?: boolean
+  showBadge?: boolean
+  showExpanded?: boolean
+  /** Nesting depth for indented sub-items (0 = root) */
+  level?: number
+  /** When true, sets role="option" + aria-selected for listbox patterns */
+  selectable?: boolean
+  selected?: boolean
+  disabled?: boolean
+  error?: boolean
+}

--- a/src/components/common/AdvancedListV2/RcSesAdvancedListV2.test.ts
+++ b/src/components/common/AdvancedListV2/RcSesAdvancedListV2.test.ts
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/vue'
+import { describe, expect, it } from 'vitest'
+
+import RcSesAdvancedListItemV2 from '@/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.vue'
+
+import RcSesAdvancedListV2 from './RcSesAdvancedListV2.vue'
+
+describe('RcSesAdvancedListV2', () => {
+  it('renders a labelled list with items', () => {
+    render({
+      components: { RcSesAdvancedListV2, RcSesAdvancedListItemV2 },
+      template: `
+        <RcSesAdvancedListV2 accessible-label="Mokėjimo būdai">
+          <RcSesAdvancedListItemV2 title="Swedbank" :show-trailing="false" />
+          <RcSesAdvancedListItemV2 title="SEB" :show-trailing="false" />
+        </RcSesAdvancedListV2>
+      `,
+    })
+
+    expect(screen.getByRole('list', { name: 'Mokėjimo būdai' })).toBeInTheDocument()
+    expect(screen.getByText('Swedbank')).toBeInTheDocument()
+    expect(screen.getByText('SEB')).toBeInTheDocument()
+  })
+
+  it('sets listbox role and aria-multiselectable when multiselectable', () => {
+    render({
+      components: { RcSesAdvancedListV2, RcSesAdvancedListItemV2 },
+      template: `
+        <RcSesAdvancedListV2 multiselectable accessible-label="Objektai">
+          <RcSesAdvancedListItemV2 title="Objektas" selectable />
+        </RcSesAdvancedListV2>
+      `,
+    })
+
+    const listbox = screen.getByRole('listbox', { name: 'Objektai' })
+    expect(listbox).toHaveAttribute('aria-multiselectable', 'true')
+    expect(screen.getByRole('option')).toBeInTheDocument()
+  })
+
+  it('sets listbox role when listbox prop is true', () => {
+    render({
+      components: { RcSesAdvancedListV2, RcSesAdvancedListItemV2 },
+      template: `
+        <RcSesAdvancedListV2 listbox accessible-label="Single select">
+          <RcSesAdvancedListItemV2 title="Option" selectable />
+        </RcSesAdvancedListV2>
+      `,
+    })
+
+    expect(screen.getByRole('listbox', { name: 'Single select' })).toBeInTheDocument()
+    expect(screen.getByRole('option')).toBeInTheDocument()
+  })
+
+  it('applies framed and scrollable modifiers', () => {
+    const { container } = render({
+      components: { RcSesAdvancedListV2, RcSesAdvancedListItemV2 },
+      template: `
+        <RcSesAdvancedListV2 framed :max-height="200" accessible-label="Panel">
+          <RcSesAdvancedListItemV2 title="Item" :show-trailing="false" />
+        </RcSesAdvancedListV2>
+      `,
+    })
+
+    const list = container.querySelector('.rc-ses-advanced-list-v2')
+    expect(list).toHaveClass('rc-ses-advanced-list-v2--framed')
+    expect(list).toHaveClass('rc-ses-advanced-list-v2--scrollable')
+    expect(list).toHaveStyle({ maxHeight: '200px' })
+  })
+})

--- a/src/components/common/AdvancedListV2/RcSesAdvancedListV2.test.ts
+++ b/src/components/common/AdvancedListV2/RcSesAdvancedListV2.test.ts
@@ -66,4 +66,18 @@ describe('RcSesAdvancedListV2', () => {
     expect(list).toHaveClass('rc-ses-advanced-list-v2--scrollable')
     expect(list).toHaveStyle({ maxHeight: '200px' })
   })
+
+  it('does not set option role when selectable without listbox parent', () => {
+    render({
+      components: { RcSesAdvancedListV2, RcSesAdvancedListItemV2 },
+      template: `
+        <RcSesAdvancedListV2 accessible-label="Plain list">
+          <RcSesAdvancedListItemV2 title="Option" selectable selected />
+        </RcSesAdvancedListV2>
+      `,
+    })
+
+    expect(screen.getByRole('list', { name: 'Plain list' })).toBeInTheDocument()
+    expect(screen.queryByRole('option')).not.toBeInTheDocument()
+  })
 })

--- a/src/components/common/AdvancedListV2/RcSesAdvancedListV2.vue
+++ b/src/components/common/AdvancedListV2/RcSesAdvancedListV2.vue
@@ -1,0 +1,47 @@
+<template>
+  <ul
+    :class="rootClasses"
+    :style="rootStyle"
+    :role="listRole"
+    :aria-label="props.accessibleLabel"
+    :aria-multiselectable="props.multiselectable || undefined"
+  >
+    <slot />
+  </ul>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import advancedListV2Defaults from '@/components/common/AdvancedListV2/defaults'
+import type { AdvancedListProps } from '@/components/common/AdvancedListV2/types'
+
+import './style.scss'
+
+const props = withDefaults(defineProps<AdvancedListProps>(), advancedListV2Defaults)
+
+const isListbox = computed(() => props.listbox || props.multiselectable)
+
+const listRole = computed(() => (isListbox.value ? 'listbox' : undefined))
+
+const rootClasses = computed(() => [
+  'rc-ses-advanced-list-v2',
+  `rc-ses-advanced-list-v2--${props.variant}`,
+  {
+    'rc-ses-advanced-list-v2--framed': props.framed,
+    'rc-ses-advanced-list-v2--scrollable':
+      props.maxHeight != null && props.maxHeight !== '',
+  },
+])
+
+const rootStyle = computed(() => {
+  if (props.maxHeight == null || props.maxHeight === '') {
+    return undefined
+  }
+
+  const maxHeight =
+    typeof props.maxHeight === 'number' ? `${props.maxHeight}px` : props.maxHeight
+
+  return { maxHeight }
+})
+</script>

--- a/src/components/common/AdvancedListV2/RcSesAdvancedListV2.vue
+++ b/src/components/common/AdvancedListV2/RcSesAdvancedListV2.vue
@@ -11,8 +11,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, provide } from 'vue'
 
+import { advancedListV2Key } from '@/components/common/AdvancedListV2/context'
 import advancedListV2Defaults from '@/components/common/AdvancedListV2/defaults'
 import type { AdvancedListProps } from '@/components/common/AdvancedListV2/types'
 
@@ -21,6 +22,8 @@ import './style.scss'
 const props = withDefaults(defineProps<AdvancedListProps>(), advancedListV2Defaults)
 
 const isListbox = computed(() => props.listbox || props.multiselectable)
+
+provide(advancedListV2Key, { isListbox })
 
 const listRole = computed(() => (isListbox.value ? 'listbox' : undefined))
 

--- a/src/components/common/AdvancedListV2/context.ts
+++ b/src/components/common/AdvancedListV2/context.ts
@@ -1,0 +1,8 @@
+import type { ComputedRef, InjectionKey } from 'vue'
+
+export type AdvancedListV2Context = {
+  isListbox: ComputedRef<boolean>
+}
+
+export const advancedListV2Key: InjectionKey<AdvancedListV2Context> =
+  Symbol('RcSesAdvancedListV2')

--- a/src/components/common/AdvancedListV2/defaults.ts
+++ b/src/components/common/AdvancedListV2/defaults.ts
@@ -1,0 +1,17 @@
+import type { AdvancedListVariant } from '@/components/common/AdvancedListV2/types'
+
+export type AdvancedListDefaultsType = {
+  variant: AdvancedListVariant
+  listbox: boolean
+  multiselectable: boolean
+  framed: boolean
+}
+
+const advancedListV2Defaults = {
+  variant: 'card',
+  listbox: false,
+  multiselectable: false,
+  framed: false,
+} satisfies AdvancedListDefaultsType
+
+export default advancedListV2Defaults

--- a/src/components/common/AdvancedListV2/style.scss
+++ b/src/components/common/AdvancedListV2/style.scss
@@ -1,0 +1,33 @@
+@use '/src/styles/vuetify/borders-v2' as borders-v2;
+@use '/src/styles/vuetify/spacing-v2' as spacing-v2;
+
+.rc-ses-advanced-list-v2 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: spacing-v2.rc-spacing-v2('list-item-gap-v2');
+  list-style: none;
+  margin: 0;
+  max-width: 100%;
+  min-width: 0;
+  padding: 0;
+  width: 100%;
+
+  &--row {
+    gap: 0;
+  }
+
+  &--framed {
+    background-color: rgb(var(--v-theme-surface-base-v2));
+    border: borders-v2.rc-stroke-v2('border-width-default-v2') solid
+      rgb(var(--v-theme-border-subtle-v2));
+    border-radius: borders-v2.rc-radius-v2('list-item-radius-v2');
+    overflow-x: clip;
+    padding: spacing-v2.rc-spacing-v2('list-panel-padding-v2');
+  }
+
+  &--scrollable {
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+}

--- a/src/components/common/AdvancedListV2/types.ts
+++ b/src/components/common/AdvancedListV2/types.ts
@@ -1,0 +1,21 @@
+export type AdvancedListVariant = 'card' | 'row'
+
+export type AdvancedListProps = {
+  /** Matches child item container; row lists use 0 gap + dividers on items */
+  variant?: AdvancedListVariant
+  /**
+   * Sets role="listbox" for selectable option children.
+   * Also enabled automatically when multiselectable is true.
+   */
+  listbox?: boolean
+  /** Multi-select listbox semantics on the parent list */
+  multiselectable?: boolean
+  accessibleLabel?: string
+  /**
+   * Bordered panel surface around the list (bg, border, radius, padding).
+   * Use with maxHeight for scrollable result panels.
+   */
+  framed?: boolean
+  /** When set, list becomes vertically scrollable (e.g. 280 or '280px') */
+  maxHeight?: number | string
+}

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -3,6 +3,8 @@ import 'vuetify/styles'
 
 import RcSesAccordion from '@/components/common/Accordion/RcSesAccordion.vue'
 import useAccordionController from '@/components/common/Accordion/hooks/useAccordionController'
+import RcSesAdvancedListItemV2 from '@/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.vue'
+import RcSesAdvancedListV2 from '@/components/common/AdvancedListV2/RcSesAdvancedListV2.vue'
 import RcSesAlert from '@/components/common/Alert/RcSesAlert.vue'
 import RcSesBadgeV2 from '@/components/common/BadgeV2/RcSesBadgeV2.vue'
 import RcSesCardFooterV2 from '@/components/common/CardV2/RcSesCardFooterV2.vue'
@@ -143,6 +145,8 @@ export function createRcSesComponents(options: object = {}): Plugin<[]> {
     app.component('RcSesTooltip', RcSesTooltip)
 
     app.component('RcSesBadgeV2', RcSesBadgeV2)
+    app.component('RcSesAdvancedListV2', RcSesAdvancedListV2)
+    app.component('RcSesAdvancedListItemV2', RcSesAdvancedListItemV2)
     app.component('RcSesChipSelectV2', RcSesChipSelectV2)
     app.component('RcSesCheckboxV2', RcSesCheckboxV2)
     app.component('RcSesCheckboxSelectableAreaV2', RcSesCheckboxSelectableAreaV2)
@@ -177,6 +181,7 @@ export {
 
 export { RcSesAlert, RcSesButton }
 export { RcSesBadgeV2, RcSesButtonV2, RcSesToggleV2 }
+export { RcSesAdvancedListV2, RcSesAdvancedListItemV2 }
 export { RcSesRadioGroupV2, RcSesRadioV2, RcSesRadioSelectableAreaV2 }
 export { RcSesImageAndTextV2, RcSesSnackbarV2 }
 export { RcSesInlineAlertV2, RcSesStepperV2 }

--- a/src/stories/components v2/AdvancedList/AdvancedList.stories.ts
+++ b/src/stories/components v2/AdvancedList/AdvancedList.stories.ts
@@ -1,0 +1,525 @@
+import type { Meta, StoryFn } from '@storybook/vue3'
+import { ref } from 'vue'
+
+import RcSesAdvancedListItemV2 from '@/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.vue'
+import RcSesAdvancedListV2 from '@/components/common/AdvancedListV2/RcSesAdvancedListV2.vue'
+import RcSesPriceDisplayV2 from '@/components/common/PriceDisplayV2/RcSesPriceDisplayV2.vue'
+import RcSesCheckboxV2 from '@/components/common/inputs/Checkboxes/CheckboxV2/RcSesCheckboxV2.vue'
+import RcSesRadioGroupV2 from '@/components/common/inputs/Radios/RadioGroupV2/RcSesRadioGroupV2.vue'
+import RcSesRadioV2 from '@/components/common/inputs/Radios/RadioV2/RcSesRadioV2.vue'
+
+const meta: Meta<typeof RcSesAdvancedListV2> = {
+  title: 'componentsV2/AdvancedList',
+  component: RcSesAdvancedListV2,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['card', 'row'],
+      description: 'Card list uses gap; row list uses item dividers',
+    },
+    multiselectable: {
+      control: 'boolean',
+      description: 'Sets aria-multiselectable (also enables listbox role)',
+    },
+    listbox: {
+      control: 'boolean',
+      description: 'Sets role=listbox for selectable option children',
+    },
+    accessibleLabel: {
+      control: 'text',
+      description: 'Accessible name for the list',
+    },
+    framed: {
+      control: 'boolean',
+      description: 'Bordered panel surface (bg, border, padding)',
+    },
+    maxHeight: {
+      control: 'text',
+      description: 'Scrollable max height (e.g. 280 or 280px)',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryFn<typeof RcSesAdvancedListV2>
+
+export const Default: Story = (args) => ({
+  components: { RcSesAdvancedListV2, RcSesAdvancedListItemV2 },
+  setup() {
+    return { args }
+  },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <div class="advanced-list-story">
+          <RcSesAdvancedListV2 v-bind="args">
+            <RcSesAdvancedListItemV2
+              :container="args.variant"
+              title="First item"
+              subtitle="Supporting text"
+              :show-leading="false"
+              :show-trailing="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-expanded="false"
+            />
+            <RcSesAdvancedListItemV2
+              :container="args.variant"
+              title="Second item"
+              subtitle="Supporting text"
+              :show-leading="false"
+              :show-trailing="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-expanded="false"
+            />
+            <RcSesAdvancedListItemV2
+              :container="args.variant"
+              title="Third item"
+              subtitle="Supporting text"
+              :show-leading="false"
+              :show-trailing="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-expanded="false"
+            />
+          </RcSesAdvancedListV2>
+        </div>
+      </div>
+    </div>
+  `,
+})
+Default.args = {
+  variant: 'card',
+  accessibleLabel: 'Example list',
+  listbox: false,
+  multiselectable: false,
+  framed: false,
+  maxHeight: undefined,
+}
+
+export const VariantCard: Story = (args) => ({
+  components: { RcSesAdvancedListV2, RcSesAdvancedListItemV2 },
+  setup() {
+    return { args }
+  },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <div class="advanced-list-story">
+          <RcSesAdvancedListV2 v-bind="args">
+            <RcSesAdvancedListItemV2
+              container="card"
+              title="Card list item one"
+              subtitle="Gap between bordered cards"
+              :show-leading="false"
+              :show-trailing="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-expanded="false"
+            />
+            <RcSesAdvancedListItemV2
+              container="card"
+              title="Card list item two"
+              subtitle="Gap between bordered cards"
+              :show-leading="false"
+              :show-trailing="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-expanded="false"
+            />
+          </RcSesAdvancedListV2>
+        </div>
+      </div>
+    </div>
+  `,
+})
+VariantCard.args = {
+  variant: 'card',
+  accessibleLabel: 'Card list',
+}
+
+export const VariantRow: Story = (args) => ({
+  components: {
+    RcSesAdvancedListV2,
+    RcSesAdvancedListItemV2,
+    RcSesPriceDisplayV2,
+  },
+  setup() {
+    return { args }
+  },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <div class="advanced-list-story">
+          <RcSesAdvancedListV2 v-bind="args">
+            <RcSesAdvancedListItemV2
+              container="row"
+              title="Row list item one"
+              subtitle="Dividers between rows"
+              :show-leading="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-expanded="false"
+            >
+              <template #trailing>
+                <RcSesPriceDisplayV2 price="12.00 €" label="VAT incl." />
+              </template>
+            </RcSesAdvancedListItemV2>
+            <RcSesAdvancedListItemV2
+              container="row"
+              title="Row list item two"
+              subtitle="Dividers between rows"
+              :show-leading="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-expanded="false"
+            >
+              <template #trailing>
+                <RcSesPriceDisplayV2 price="4.16 €" label="VAT incl." />
+              </template>
+            </RcSesAdvancedListItemV2>
+          </RcSesAdvancedListV2>
+        </div>
+      </div>
+    </div>
+  `,
+})
+VariantRow.args = {
+  variant: 'row',
+  accessibleLabel: 'Row list',
+}
+
+export const MultiSelect: Story = (args) => ({
+  components: {
+    RcSesAdvancedListV2,
+    RcSesAdvancedListItemV2,
+    RcSesCheckboxV2,
+  },
+  setup() {
+    const items = [
+      { id: 'a', title: 'Option A', subtitle: 'First choice' },
+      { id: 'b', title: 'Option B', subtitle: 'Second choice' },
+      { id: 'c', title: 'Option C', subtitle: 'Third choice' },
+    ]
+    const selectedIds = ref<string[]>(['a'])
+
+    const toggle = (id: string) => {
+      if (selectedIds.value.includes(id)) {
+        selectedIds.value = selectedIds.value.filter((value) => value !== id)
+        return
+      }
+      selectedIds.value = [...selectedIds.value, id]
+    }
+
+    return { args, items, selectedIds, toggle }
+  },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <div class="advanced-list-story">
+          <p class="text-body-small-v2" style="margin-bottom: 12px;">
+            Selected: {{ selectedIds.join(', ') || 'none' }}
+          </p>
+          <RcSesAdvancedListV2 v-bind="args">
+            <RcSesAdvancedListItemV2
+              v-for="item in items"
+              :key="item.id"
+              :container="args.variant"
+              :title="item.title"
+              :subtitle="item.subtitle"
+              selectable
+              :selected="selectedIds.includes(item.id)"
+              :show-meta="false"
+              :show-badge="false"
+              :show-trailing="false"
+              :show-expanded="false"
+              @select="toggle(item.id)"
+            >
+              <template #leading>
+                <RcSesCheckboxV2
+                  :model-value="selectedIds.includes(item.id)"
+                  :show-label="false"
+                  accessible-label="Select option"
+                />
+              </template>
+            </RcSesAdvancedListItemV2>
+          </RcSesAdvancedListV2>
+        </div>
+      </div>
+    </div>
+  `,
+})
+MultiSelect.args = {
+  variant: 'card',
+  accessibleLabel: 'Multi-select list',
+  multiselectable: true,
+}
+
+export const SingleSelect: Story = (args) => ({
+  components: { RcSesAdvancedListV2, RcSesAdvancedListItemV2 },
+  setup() {
+    const items = [
+      { id: 'one', title: 'Option one', subtitle: 'Single choice list' },
+      { id: 'two', title: 'Option two', subtitle: 'Single choice list' },
+      { id: 'three', title: 'Option three', subtitle: 'Single choice list' },
+    ]
+    const selectedId = ref<string | null>('one')
+
+    const select = (id: string) => {
+      selectedId.value = id
+    }
+
+    return { args, items, selectedId, select }
+  },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <div class="advanced-list-story">
+          <p class="text-body-small-v2" style="margin-bottom: 12px;">
+            Selected: {{ selectedId || 'none' }}
+          </p>
+          <RcSesAdvancedListV2 v-bind="args">
+            <RcSesAdvancedListItemV2
+              v-for="item in items"
+              :key="item.id"
+              :container="args.variant"
+              :title="item.title"
+              :subtitle="item.subtitle"
+              selectable
+              :selected="selectedId === item.id"
+              :show-leading="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-trailing="false"
+              :show-expanded="false"
+              @select="select(item.id)"
+            />
+          </RcSesAdvancedListV2>
+        </div>
+      </div>
+    </div>
+  `,
+})
+SingleSelect.args = {
+  variant: 'card',
+  accessibleLabel: 'Single-select list',
+  listbox: true,
+  multiselectable: false,
+}
+
+export const FramedScrollable: Story = (args) => ({
+  components: { RcSesAdvancedListV2, RcSesAdvancedListItemV2 },
+  setup() {
+    const items = Array.from({ length: 8 }, (_, index) => ({
+      id: `item-${index + 1}`,
+      title: `Scrollable item ${index + 1}`,
+      subtitle: 'Inside a framed panel with maxHeight',
+    }))
+
+    return { args, items }
+  },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <div class="advanced-list-story">
+          <RcSesAdvancedListV2 v-bind="args">
+            <RcSesAdvancedListItemV2
+              v-for="item in items"
+              :key="item.id"
+              :container="args.variant"
+              :title="item.title"
+              :subtitle="item.subtitle"
+              :show-leading="false"
+              :show-trailing="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-expanded="false"
+            />
+          </RcSesAdvancedListV2>
+        </div>
+      </div>
+    </div>
+  `,
+})
+FramedScrollable.args = {
+  variant: 'card',
+  accessibleLabel: 'Framed scrollable list',
+  framed: true,
+  maxHeight: 240,
+}
+
+export const NestedLevels: Story = () => ({
+  components: {
+    RcSesAdvancedListV2,
+    RcSesAdvancedListItemV2,
+    RcSesCheckboxV2,
+  },
+  setup() {
+    const selectedIds = ref<string[]>(['parent', 'child-a'])
+
+    const isSelected = (id: string) => selectedIds.value.includes(id)
+
+    const toggle = (id: string) => {
+      if (selectedIds.value.includes(id)) {
+        selectedIds.value = selectedIds.value.filter((value) => value !== id)
+        return
+      }
+      selectedIds.value = [...selectedIds.value, id]
+    }
+
+    return { selectedIds, isSelected, toggle }
+  },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <div class="advanced-list-story">
+          <RcSesAdvancedListV2
+            framed
+            :max-height="320"
+            multiselectable
+            accessible-label="Nested levels"
+          >
+            <RcSesAdvancedListItemV2
+              title="Parent item"
+              subtitle="Root level"
+              selectable
+              :selected="isSelected('parent')"
+              :show-meta="false"
+              :show-badge="false"
+              :show-trailing="false"
+              :show-expanded="false"
+              @select="toggle('parent')"
+            >
+              <template #leading>
+                <RcSesCheckboxV2
+                  :model-value="isSelected('parent')"
+                  :show-label="false"
+                  accessible-label="Parent"
+                />
+              </template>
+            </RcSesAdvancedListItemV2>
+            <RcSesAdvancedListItemV2
+              :level="1"
+              title="Child A"
+              selectable
+              :selected="isSelected('child-a')"
+              :show-subtitle="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-trailing="false"
+              :show-expanded="false"
+              @select="toggle('child-a')"
+            >
+              <template #leading>
+                <RcSesCheckboxV2
+                  :model-value="isSelected('child-a')"
+                  :show-label="false"
+                  accessible-label="Child A"
+                />
+              </template>
+            </RcSesAdvancedListItemV2>
+            <RcSesAdvancedListItemV2
+              :level="1"
+              title="Child B"
+              selectable
+              :selected="isSelected('child-b')"
+              :show-subtitle="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-trailing="false"
+              :show-expanded="false"
+              @select="toggle('child-b')"
+            >
+              <template #leading>
+                <RcSesCheckboxV2
+                  :model-value="isSelected('child-b')"
+                  :show-label="false"
+                  accessible-label="Child B"
+                />
+              </template>
+            </RcSesAdvancedListItemV2>
+            <RcSesAdvancedListItemV2
+              :level="2"
+              title="Grandchild"
+              selectable
+              :selected="isSelected('grandchild')"
+              :show-subtitle="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-trailing="false"
+              :show-expanded="false"
+              @select="toggle('grandchild')"
+            >
+              <template #leading>
+                <RcSesCheckboxV2
+                  :model-value="isSelected('grandchild')"
+                  :show-label="false"
+                  accessible-label="Grandchild"
+                />
+              </template>
+            </RcSesAdvancedListItemV2>
+          </RcSesAdvancedListV2>
+        </div>
+      </div>
+    </div>
+  `,
+})
+
+export const RadioSelection: Story = () => ({
+  components: {
+    RcSesRadioGroupV2,
+    RcSesAdvancedListV2,
+    RcSesAdvancedListItemV2,
+    RcSesRadioV2,
+  },
+  setup() {
+    const selectedId = ref('option-a')
+    const items = [
+      { id: 'option-a', title: 'Option A', subtitle: 'First choice' },
+      { id: 'option-b', title: 'Option B', subtitle: 'Second choice' },
+      { id: 'option-c', title: 'Option C', subtitle: 'Third choice' },
+    ]
+
+    return { selectedId, items }
+  },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <div class="advanced-list-story">
+          <p class="text-body-small-v2" style="margin-bottom: 12px;">
+            Selected: {{ selectedId }}
+          </p>
+          <RcSesRadioGroupV2 v-model="selectedId" accessible-label="Radio selection">
+            <RcSesAdvancedListV2 accessible-label="Radio selection list">
+              <RcSesAdvancedListItemV2
+                v-for="item in items"
+                :key="item.id"
+                :title="item.title"
+                :subtitle="item.subtitle"
+                selectable
+                :selected="selectedId === item.id"
+                :show-trailing="false"
+                @select="selectedId = item.id"
+              >
+                <template #leading>
+                  <RcSesRadioV2
+                    decorative
+                    :value="item.id"
+                    :show-label="false"
+                    :accessible-label="item.title"
+                  />
+                </template>
+              </RcSesAdvancedListItemV2>
+            </RcSesAdvancedListV2>
+          </RcSesRadioGroupV2>
+        </div>
+      </div>
+    </div>
+  `,
+})

--- a/src/stories/components v2/AdvancedListItem/AdvancedListItem.stories.ts
+++ b/src/stories/components v2/AdvancedListItem/AdvancedListItem.stories.ts
@@ -1,0 +1,446 @@
+import type { Meta, StoryFn } from '@storybook/vue3'
+import { ref } from 'vue'
+
+import RcSesAdvancedListItemV2 from '@/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.vue'
+import RcSesAdvancedListV2 from '@/components/common/AdvancedListV2/RcSesAdvancedListV2.vue'
+import RcSesBadgeV2 from '@/components/common/BadgeV2/RcSesBadgeV2.vue'
+import RcSesPriceDisplayV2 from '@/components/common/PriceDisplayV2/RcSesPriceDisplayV2.vue'
+import RcSesButtonV2 from '@/components/common/buttonV2/RcSesButtonV2.vue'
+import RcSesCheckboxV2 from '@/components/common/inputs/Checkboxes/CheckboxV2/RcSesCheckboxV2.vue'
+import RcSesToggleV2 from '@/components/common/toggleV2/RcSesToggleV2.vue'
+
+const meta: Meta<typeof RcSesAdvancedListItemV2> = {
+  title: 'componentsV2/AdvancedListItem',
+  component: RcSesAdvancedListItemV2,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+  },
+  argTypes: {
+    container: {
+      control: 'select',
+      options: ['card', 'row'],
+      description: 'Card = bordered tile; Row = divider list row',
+    },
+    title: { control: 'text' },
+    subtitle: { control: 'text' },
+    showLeading: {
+      control: 'boolean',
+      description: 'Toggle #leading slot visibility',
+    },
+    showLeadingMedia: {
+      control: 'boolean',
+      description: 'Toggle #leading-media slot visibility',
+    },
+    showTrailing: {
+      control: 'boolean',
+      description: 'Toggle #trailing slot visibility',
+    },
+    showSubtitle: { control: 'boolean' },
+    showMeta: {
+      control: 'boolean',
+      description: 'Toggle #meta slot visibility',
+    },
+    showBadge: {
+      control: 'boolean',
+      description: 'Toggle #badge slot visibility',
+    },
+    showExpanded: {
+      control: 'boolean',
+      description: 'Toggle #expanded slot visibility',
+    },
+    level: {
+      control: { type: 'number', min: 0, max: 3, step: 1 },
+      description: 'Nesting indent level (0 = root)',
+    },
+    selectable: {
+      control: 'boolean',
+      description: 'Whole-item click/keyboard select',
+    },
+    selected: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    error: { control: 'boolean' },
+  },
+}
+
+export default meta
+
+type Story = StoryFn<typeof RcSesAdvancedListItemV2>
+
+export const Default: Story = (args) => ({
+  components: {
+    RcSesAdvancedListV2,
+    RcSesAdvancedListItemV2,
+    RcSesCheckboxV2,
+    RcSesBadgeV2,
+    RcSesButtonV2,
+  },
+  setup() {
+    const onSelect = () => {
+      if (!args.selectable || args.disabled) {
+        return
+      }
+      // Storybook args proxy — toggle selected for Controls playground
+      // eslint-disable-next-line no-param-reassign -- intentional Controls sync
+      args.selected = !args.selected
+    }
+
+    return { args, onSelect }
+  },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <div class="advanced-list-story">
+          <RcSesAdvancedListV2 accessible-label="List item playground">
+            <RcSesAdvancedListItemV2 v-bind="args" @select="onSelect">
+              <template #leading>
+                <RcSesCheckboxV2
+                  :model-value="args.selected"
+                  :show-label="false"
+                  accessible-label="Select item"
+                />
+              </template>
+              <template #leading-media>
+                <span style="font-weight: 600;">AB</span>
+              </template>
+              <template #badge>
+                <RcSesBadgeV2 type="info" size="small">Label</RcSesBadgeV2>
+              </template>
+              <template #meta>
+                <span class="text-body-caption-v2">Meta one</span>
+                <span class="text-body-caption-v2">Meta two</span>
+              </template>
+              <template #trailing>
+                <RcSesButtonV2 variant="link" size="small">Action</RcSesButtonV2>
+              </template>
+              <template #expanded>
+                Expanded panel content.
+              </template>
+              Optional description slot.
+            </RcSesAdvancedListItemV2>
+          </RcSesAdvancedListV2>
+        </div>
+      </div>
+    </div>
+  `,
+})
+Default.args = {
+  container: 'card',
+  title: 'Item title',
+  subtitle: 'Supporting subtitle',
+  showLeading: true,
+  showLeadingMedia: false,
+  showTrailing: true,
+  showSubtitle: true,
+  showMeta: false,
+  showBadge: true,
+  showExpanded: false,
+  level: 0,
+  selectable: true,
+  selected: false,
+  disabled: false,
+  error: false,
+}
+
+export const Containers: Story = () => ({
+  components: {
+    RcSesAdvancedListV2,
+    RcSesAdvancedListItemV2,
+    RcSesButtonV2,
+    RcSesPriceDisplayV2,
+  },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <div class="advanced-list-story" style="display: flex; flex-direction: column; gap: 24px;">
+          <div>
+            <p class="text-body-small-v2" style="margin-bottom: 8px;">Card</p>
+            <RcSesAdvancedListV2 variant="card" accessible-label="Card container">
+              <RcSesAdvancedListItemV2
+                container="card"
+                title="Card item"
+                subtitle="Bordered tile with gap"
+                :show-leading="false"
+                :show-meta="false"
+                :show-badge="false"
+                :show-expanded="false"
+              >
+                <template #trailing>
+                  <RcSesButtonV2 variant="link" size="small">Action</RcSesButtonV2>
+                </template>
+              </RcSesAdvancedListItemV2>
+            </RcSesAdvancedListV2>
+          </div>
+          <div>
+            <p class="text-body-small-v2" style="margin-bottom: 8px;">Row</p>
+            <RcSesAdvancedListV2 variant="row" accessible-label="Row container">
+              <RcSesAdvancedListItemV2
+                container="row"
+                title="Row item"
+                subtitle="Divider layout"
+                :show-leading="false"
+                :show-meta="false"
+                :show-badge="false"
+                :show-expanded="false"
+              >
+                <template #trailing>
+                  <RcSesPriceDisplayV2 price="12.00 €" label="VAT incl." />
+                </template>
+              </RcSesAdvancedListItemV2>
+              <RcSesAdvancedListItemV2
+                container="row"
+                title="Another row"
+                subtitle="Second entry"
+                :show-leading="false"
+                :show-meta="false"
+                :show-badge="false"
+                :show-expanded="false"
+              >
+                <template #trailing>
+                  <RcSesPriceDisplayV2 price="4.16 €" label="VAT incl." />
+                </template>
+              </RcSesAdvancedListItemV2>
+            </RcSesAdvancedListV2>
+          </div>
+        </div>
+      </div>
+    </div>
+  `,
+})
+
+export const States: Story = () => ({
+  components: { RcSesAdvancedListV2, RcSesAdvancedListItemV2 },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <div class="advanced-list-story">
+          <RcSesAdvancedListV2 accessible-label="Item states">
+            <RcSesAdvancedListItemV2
+              title="Rest"
+              :show-leading="false"
+              :show-subtitle="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-trailing="false"
+              :show-expanded="false"
+            />
+            <RcSesAdvancedListItemV2
+              title="Selected"
+              selected
+              :show-leading="false"
+              :show-subtitle="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-trailing="false"
+              :show-expanded="false"
+            />
+            <RcSesAdvancedListItemV2
+              title="Error"
+              error
+              :show-leading="false"
+              :show-subtitle="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-trailing="false"
+              :show-expanded="false"
+            />
+            <RcSesAdvancedListItemV2
+              title="Disabled"
+              disabled
+              :show-leading="false"
+              :show-subtitle="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-trailing="false"
+              :show-expanded="false"
+            />
+          </RcSesAdvancedListV2>
+        </div>
+      </div>
+    </div>
+  `,
+})
+
+export const Selectable: Story = () => ({
+  components: {
+    RcSesAdvancedListV2,
+    RcSesAdvancedListItemV2,
+    RcSesCheckboxV2,
+  },
+  setup() {
+    const items = [
+      { id: 'a', title: 'Option A', subtitle: 'Click the card to toggle' },
+      { id: 'b', title: 'Option B', subtitle: 'Click the card to toggle' },
+      { id: 'c', title: 'Option C', subtitle: 'Click the card to toggle' },
+    ]
+    const selectedIds = ref<string[]>(['a'])
+
+    const isSelected = (id: string) => selectedIds.value.includes(id)
+
+    const toggle = (id: string) => {
+      if (selectedIds.value.includes(id)) {
+        selectedIds.value = selectedIds.value.filter((value) => value !== id)
+        return
+      }
+      selectedIds.value = [...selectedIds.value, id]
+    }
+
+    return { items, selectedIds, isSelected, toggle }
+  },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <div class="advanced-list-story">
+          <p class="text-body-small-v2" style="margin-bottom: 12px;">
+            Selected: {{ selectedIds.join(', ') || 'none' }}
+          </p>
+          <RcSesAdvancedListV2 multiselectable accessible-label="Selectable items">
+            <RcSesAdvancedListItemV2
+              v-for="item in items"
+              :key="item.id"
+              :title="item.title"
+              :subtitle="item.subtitle"
+              selectable
+              :selected="isSelected(item.id)"
+              :show-meta="false"
+              :show-badge="false"
+              :show-trailing="false"
+              :show-expanded="false"
+              @select="toggle(item.id)"
+            >
+              <template #leading>
+                <RcSesCheckboxV2
+                  :model-value="isSelected(item.id)"
+                  :show-label="false"
+                  :accessible-label="item.title"
+                />
+              </template>
+            </RcSesAdvancedListItemV2>
+          </RcSesAdvancedListV2>
+        </div>
+      </div>
+    </div>
+  `,
+})
+
+export const Trailing: Story = () => ({
+  components: {
+    RcSesAdvancedListV2,
+    RcSesAdvancedListItemV2,
+    RcSesButtonV2,
+    RcSesToggleV2,
+    RcSesBadgeV2,
+    RcSesPriceDisplayV2,
+  },
+  setup() {
+    const enabled = ref(false)
+    return { enabled }
+  },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <div class="advanced-list-story">
+          <RcSesAdvancedListV2 accessible-label="Trailing examples">
+            <RcSesAdvancedListItemV2
+              title="Actions"
+              subtitle="Edit / remove links"
+              :show-leading="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-expanded="false"
+            >
+              <template #trailing>
+                <RcSesButtonV2 variant="link" size="small" prepend-icon="$notePencil">Edit</RcSesButtonV2>
+                <RcSesButtonV2 variant="link" size="small" prepend-icon="$trash">Remove</RcSesButtonV2>
+              </template>
+            </RcSesAdvancedListItemV2>
+            <RcSesAdvancedListItemV2
+              title="Toggle"
+              subtitle="Independent control"
+              :show-leading="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-expanded="false"
+            >
+              <template #trailing>
+                <RcSesToggleV2 v-model="enabled" :show-label="false" aria-label="Enable" />
+              </template>
+            </RcSesAdvancedListItemV2>
+            <RcSesAdvancedListItemV2
+              title="Badge"
+              subtitle="Status example"
+              :show-leading="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-expanded="false"
+            >
+              <template #trailing>
+                <RcSesBadgeV2 type="warning" show-icon>Pending</RcSesBadgeV2>
+              </template>
+            </RcSesAdvancedListItemV2>
+            <RcSesAdvancedListItemV2
+              title="Price"
+              subtitle="Amount display"
+              :show-leading="false"
+              :show-meta="false"
+              :show-badge="false"
+              :show-expanded="false"
+            >
+              <template #trailing>
+                <RcSesPriceDisplayV2 price="12.00 €" label="VAT incl." />
+              </template>
+            </RcSesAdvancedListItemV2>
+          </RcSesAdvancedListV2>
+        </div>
+      </div>
+    </div>
+  `,
+})
+
+export const WithSlots: Story = () => ({
+  components: {
+    RcSesAdvancedListV2,
+    RcSesAdvancedListItemV2,
+    RcSesButtonV2,
+    RcSesBadgeV2,
+  },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <div class="advanced-list-story">
+          <RcSesAdvancedListV2 accessible-label="All slots">
+            <RcSesAdvancedListItemV2
+              title="Item with all common slots"
+              subtitle="Subtitle text"
+              show-leading-media
+              :show-expanded="true"
+            >
+              <template #leading>
+                <RcSesButtonV2 variant="link" size="small" icon="$caretUp" accessible-label="Move up" />
+                <RcSesButtonV2 variant="link" size="small" icon="$caretDown" accessible-label="Move down" />
+              </template>
+              <template #leading-media>
+                <span style="font-weight: 600;">AB</span>
+              </template>
+              <template #badge>
+                <RcSesBadgeV2 type="info" size="small">Label</RcSesBadgeV2>
+              </template>
+              <template #meta>
+                <span class="text-body-caption-v2">Meta one</span>
+                <span class="text-body-caption-v2">Meta two</span>
+              </template>
+              <template #trailing>
+                <RcSesButtonV2 variant="link" size="small" prepend-icon="$notePencil">Edit</RcSesButtonV2>
+                <RcSesButtonV2 variant="link" size="small" prepend-icon="$trash">Remove</RcSesButtonV2>
+              </template>
+              <template #expanded>
+                Optional expanded panel content.
+              </template>
+              Optional description slot content.
+            </RcSesAdvancedListItemV2>
+          </RcSesAdvancedListV2>
+        </div>
+      </div>
+    </div>
+  `,
+})

--- a/src/styles/shared/storybook.scss
+++ b/src/styles/shared/storybook.scss
@@ -47,3 +47,10 @@
     justify-content: center !important;
   }
 }
+
+.advanced-list-story {
+  box-sizing: border-box;
+  max-width: 40rem;
+  min-width: 0;
+  width: 100%;
+}

--- a/src/styles/vuetify/_borders-v2.scss
+++ b/src/styles/vuetify/_borders-v2.scss
@@ -30,6 +30,7 @@ $rc-radius-v2-semantic: (
   'modal-radius-v2': 'radius-16-v2',
   'chip-radius-v2': 'radius-4-v2',
   'pill-radius-v2': 'radius-full-v2',
+  'list-item-radius-v2': 'radius-8-v2',
 );
 
 $rc-stroke-v2-semantic: (

--- a/src/styles/vuetify/_spacing-v2.scss
+++ b/src/styles/vuetify/_spacing-v2.scss
@@ -55,8 +55,15 @@ $rc-spacing-v2-semantic: (
   'selectable-area-padding-y-v2': 'spacing-8-v2',
   'selectable-area-padding-x-v2': 'spacing-12-v2',
   // List
+  'list-item-padding-y-v2': 'spacing-8-v2',
+  'list-item-padding-x-v2': 'spacing-12-v2',
   'list-item-padding-v2': 'spacing-16-v2',
   'list-item-gap-v2': 'spacing-12-v2',
+  'list-item-trailing-gap-v2': 'spacing-8-v2',
+  'list-item-leading-gap-v2': 'spacing-4-v2',
+  'list-item-meta-gap-v2': 'spacing-8-v2',
+  'list-item-indent-v2': 'spacing-24-v2',
+  'list-panel-padding-v2': 'spacing-12-v2',
   // Badge
   'badge-padding-x-small-v2': 'spacing-8-v2',
   'badge-padding-y-small-v2': 'spacing-4-v2',


### PR DESCRIPTION
## 🔗 Task

https://jira.registrucentras.lt/jira/browse/IRM-5294

@tomas562  @saukaite 

## 🧾 Summary

Adds RcSesAdvancedListV2 and RcSesAdvancedListItemV2 — v2 list shell and list item for card/row layouts. Items are slot-based (leading, leading-media, title, badge, meta, default, trailing, expanded) with show* flags, nesting via level, and selectable state (selected / disabled / error) that emits select. List supports variant, optional listbox / multiselectable a11y, framed panel surface, and maxHeight scrolling. Styling uses v2 tokens; includes Storybook, tests, and library export.

## 📸 Screenshots
<img width="1028" height="360" alt="image" src="https://github.com/user-attachments/assets/44f7ba12-721e-482d-9e3e-7d7246235e3d" />

<img width="1022" height="520" alt="image" src="https://github.com/user-attachments/assets/c903bd2a-0dfa-47be-8a63-fc01cce0ee31" />

<img width="1022" height="461" alt="image" src="https://github.com/user-attachments/assets/2ad025de-337e-4a90-a6a5-7e9caddb76b5" />
<img width="1023" height="418" alt="image" src="https://github.com/user-attachments/assets/9132dac0-3600-4955-b281-44b2c7cb6ac9" />
<img width="1047" height="452" alt="image" src="https://github.com/user-attachments/assets/6918a306-c8aa-4741-ade8-7189f214bf72" />
<img width="1061" height="440" alt="image" src="https://github.com/user-attachments/assets/dd4c0ca5-1d82-4061-9183-27bc5e0da41b" />
<img width="1032" height="483" alt="image" src="https://github.com/user-attachments/assets/7d5e6cac-7e7d-480e-9b57-c0150db5bcfe" />


## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [x] UI matches approved design (Figma)
* [x] Accessibility reviewed (keyboard navigation, labels, semantics)
