### PR TITLE
IRM-5294-mobile

### DIFF
--- a/src/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.test.ts
+++ b/src/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.test.ts
@@ -207,4 +207,50 @@ describe('RcSesAdvancedListItemV2', () => {
       '--rc-ses-list-item-level': '2',
     })
   })
+
+  it('applies wrap-auto class by default', () => {
+    const { container } = renderItem()
+
+    expect(container.querySelector('.rc-ses-advanced-list-item-v2')).toHaveClass(
+      'rc-ses-advanced-list-item-v2--wrap-auto',
+    )
+  })
+
+  it('applies wrap-off class', () => {
+    const { container } = renderItem({ wrap: 'off' })
+
+    expect(container.querySelector('.rc-ses-advanced-list-item-v2')).toHaveClass(
+      'rc-ses-advanced-list-item-v2--wrap-off',
+    )
+  })
+
+  it('applies wrap-stacked class with start and trailing regions', () => {
+    const { container } = renderItem(
+      { wrap: 'stacked' },
+      {
+        leading: '<span data-testid="leading">L</span>',
+        trailing: '<button type="button">Pašalinti</button>',
+      },
+    )
+
+    const item = container.querySelector('.rc-ses-advanced-list-item-v2')
+    expect(item).toHaveClass('rc-ses-advanced-list-item-v2--wrap-stacked')
+    expect(container.querySelector('.rc-ses-advanced-list-item-v2__start')).toBeTruthy()
+    expect(
+      container.querySelector('.rc-ses-advanced-list-item-v2__trailing'),
+    ).toBeTruthy()
+    expect(item).not.toHaveClass('rc-ses-advanced-list-item-v2--no-start')
+    expect(item).not.toHaveClass('rc-ses-advanced-list-item-v2--no-trailing')
+  })
+
+  it('marks stacked item without trailing', () => {
+    const { container } = renderItem(
+      { wrap: 'stacked', showTrailing: false },
+      { leading: '<span>L</span>' },
+    )
+
+    expect(container.querySelector('.rc-ses-advanced-list-item-v2')).toHaveClass(
+      'rc-ses-advanced-list-item-v2--no-trailing',
+    )
+  })
 })

--- a/src/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.test.ts
+++ b/src/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.test.ts
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
 import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
 
 import RcSesAdvancedListV2 from '@/components/common/AdvancedListV2/RcSesAdvancedListV2.vue'
 
@@ -252,5 +253,43 @@ describe('RcSesAdvancedListItemV2', () => {
     expect(container.querySelector('.rc-ses-advanced-list-item-v2')).toHaveClass(
       'rc-ses-advanced-list-item-v2--no-trailing',
     )
+  })
+
+  it('shows leading and trailing after slots are added on a later render', async () => {
+    render({
+      components: { RcSesAdvancedListItemV2 },
+      setup() {
+        const hasActions = ref(false)
+        return { hasActions }
+      },
+      template: `
+        <div>
+          <RcSesAdvancedListItemV2 title="Item" :show-leading="true" :show-trailing="true">
+            <template v-if="hasActions" #leading>
+              <span data-testid="leading">L</span>
+            </template>
+            <template v-if="hasActions" #trailing>
+              <span data-testid="trailing">T</span>
+            </template>
+          </RcSesAdvancedListItemV2>
+          <button type="button" @click="hasActions = true">Show actions</button>
+        </div>
+      `,
+    })
+
+    const item = document.querySelector('.rc-ses-advanced-list-item-v2')
+    expect(item).toHaveClass('rc-ses-advanced-list-item-v2--no-start')
+    expect(item).toHaveClass('rc-ses-advanced-list-item-v2--no-trailing')
+    expect(screen.queryByTestId('leading')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('trailing')).not.toBeInTheDocument()
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Show actions' }))
+
+    expect(screen.getByTestId('leading')).toBeInTheDocument()
+    expect(screen.getByTestId('trailing')).toBeInTheDocument()
+    expect(document.querySelector('.rc-ses-advanced-list-item-v2__start')).toBeTruthy()
+    expect(document.querySelector('.rc-ses-advanced-list-item-v2__trailing')).toBeTruthy()
+    expect(item).not.toHaveClass('rc-ses-advanced-list-item-v2--no-start')
+    expect(item).not.toHaveClass('rc-ses-advanced-list-item-v2--no-trailing')
   })
 })

--- a/src/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.vue
+++ b/src/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.vue
@@ -1,7 +1,18 @@
 <template>
   <!-- eslint-disable-next-line vuejs-accessibility/interactive-supports-focus -- tabindex bound when selectable: 0 enabled / -1 disabled -->
   <li
-    :class="rootClasses"
+    :class="[
+      rootClasses,
+      {
+        'rc-ses-advanced-list-item-v2--no-start': !(
+          (props.showLeading && $slots.leading) ||
+          (props.showLeadingMedia && $slots['leading-media'])
+        ),
+        'rc-ses-advanced-list-item-v2--no-trailing': !(
+          props.showTrailing && $slots.trailing
+        ),
+      },
+    ]"
     :style="rootStyle"
     :role="isListboxOption ? 'option' : undefined"
     :tabindex="tabIndex"
@@ -12,7 +23,13 @@
     @keydown.space.self.prevent="handleSelect"
   >
     <div class="rc-ses-advanced-list-item-v2__body">
-      <div v-if="showStart" class="rc-ses-advanced-list-item-v2__start">
+      <div
+        v-if="
+          (props.showLeading && $slots.leading) ||
+          (props.showLeadingMedia && $slots['leading-media'])
+        "
+        class="rc-ses-advanced-list-item-v2__start"
+      >
         <div
           v-if="props.showLeading && $slots.leading"
           class="rc-ses-advanced-list-item-v2__leading"
@@ -62,7 +79,7 @@
       </div>
 
       <div
-        v-if="showTrailingSlot"
+        v-if="props.showTrailing && $slots.trailing"
         class="rc-ses-advanced-list-item-v2__trailing"
         @click.stop
         @keydown.stop
@@ -83,7 +100,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, useSlots } from 'vue'
+import { computed, inject } from 'vue'
 
 import advancedListItemV2Defaults from '@/components/common/AdvancedListItemV2/defaults'
 import type { AdvancedListItemProps } from '@/components/common/AdvancedListItemV2/types'
@@ -100,7 +117,6 @@ const emit = defineEmits<{
   select: []
 }>()
 
-const slots = useSlots()
 const listContext = inject(advancedListV2Key, null)
 
 const isListboxOption = computed(() => props.selectable && !!listContext?.isListbox.value)
@@ -113,14 +129,6 @@ const tabIndex = computed(() => {
   return props.disabled ? -1 : 0
 })
 
-const showStart = computed(
-  () =>
-    (props.showLeading && !!slots.leading) ||
-    (props.showLeadingMedia && !!slots['leading-media']),
-)
-
-const showTrailingSlot = computed(() => props.showTrailing && !!slots.trailing)
-
 const rootClasses = computed(() => [
   'rc-ses-advanced-list-item-v2',
   `rc-ses-advanced-list-item-v2--${props.container}`,
@@ -130,8 +138,6 @@ const rootClasses = computed(() => [
     'rc-ses-advanced-list-item-v2--selected': props.selected,
     'rc-ses-advanced-list-item-v2--disabled': props.disabled,
     'rc-ses-advanced-list-item-v2--error': props.error,
-    'rc-ses-advanced-list-item-v2--no-start': !showStart.value,
-    'rc-ses-advanced-list-item-v2--no-trailing': !showTrailingSlot.value,
   },
 ])
 

--- a/src/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.vue
+++ b/src/components/common/AdvancedListItemV2/RcSesAdvancedListItemV2.vue
@@ -12,19 +12,21 @@
     @keydown.space.self.prevent="handleSelect"
   >
     <div class="rc-ses-advanced-list-item-v2__body">
-      <div
-        v-if="props.showLeading && $slots.leading"
-        class="rc-ses-advanced-list-item-v2__leading"
-      >
-        <slot name="leading" />
-      </div>
+      <div v-if="showStart" class="rc-ses-advanced-list-item-v2__start">
+        <div
+          v-if="props.showLeading && $slots.leading"
+          class="rc-ses-advanced-list-item-v2__leading"
+        >
+          <slot name="leading" />
+        </div>
 
-      <div
-        v-if="props.showLeadingMedia && $slots['leading-media']"
-        class="rc-ses-advanced-list-item-v2__leading-media"
-        aria-hidden="true"
-      >
-        <slot name="leading-media" />
+        <div
+          v-if="props.showLeadingMedia && $slots['leading-media']"
+          class="rc-ses-advanced-list-item-v2__leading-media"
+          aria-hidden="true"
+        >
+          <slot name="leading-media" />
+        </div>
       </div>
 
       <div class="rc-ses-advanced-list-item-v2__content">
@@ -60,7 +62,7 @@
       </div>
 
       <div
-        v-if="props.showTrailing && $slots.trailing"
+        v-if="showTrailingSlot"
         class="rc-ses-advanced-list-item-v2__trailing"
         @click.stop
         @keydown.stop
@@ -81,7 +83,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject } from 'vue'
+import { computed, inject, useSlots } from 'vue'
 
 import advancedListItemV2Defaults from '@/components/common/AdvancedListItemV2/defaults'
 import type { AdvancedListItemProps } from '@/components/common/AdvancedListItemV2/types'
@@ -98,6 +100,7 @@ const emit = defineEmits<{
   select: []
 }>()
 
+const slots = useSlots()
 const listContext = inject(advancedListV2Key, null)
 
 const isListboxOption = computed(() => props.selectable && !!listContext?.isListbox.value)
@@ -110,14 +113,25 @@ const tabIndex = computed(() => {
   return props.disabled ? -1 : 0
 })
 
+const showStart = computed(
+  () =>
+    (props.showLeading && !!slots.leading) ||
+    (props.showLeadingMedia && !!slots['leading-media']),
+)
+
+const showTrailingSlot = computed(() => props.showTrailing && !!slots.trailing)
+
 const rootClasses = computed(() => [
   'rc-ses-advanced-list-item-v2',
   `rc-ses-advanced-list-item-v2--${props.container}`,
+  `rc-ses-advanced-list-item-v2--wrap-${props.wrap}`,
   {
     'rc-ses-advanced-list-item-v2--selectable': props.selectable,
     'rc-ses-advanced-list-item-v2--selected': props.selected,
     'rc-ses-advanced-list-item-v2--disabled': props.disabled,
     'rc-ses-advanced-list-item-v2--error': props.error,
+    'rc-ses-advanced-list-item-v2--no-start': !showStart.value,
+    'rc-ses-advanced-list-item-v2--no-trailing': !showTrailingSlot.value,
   },
 ])
 

--- a/src/components/common/AdvancedListItemV2/defaults.ts
+++ b/src/components/common/AdvancedListItemV2/defaults.ts
@@ -1,16 +1,19 @@
 import type {
   AdvancedListItemContainer,
   AdvancedListItemProps,
+  AdvancedListItemWrap,
 } from '@/components/common/AdvancedListItemV2/types'
 
 export type AdvancedListItemDefaultsType = Required<
   Omit<AdvancedListItemProps, 'title' | 'subtitle'>
 > & {
   container: AdvancedListItemContainer
+  wrap: AdvancedListItemWrap
 }
 
 const advancedListItemV2Defaults = {
   container: 'card',
+  wrap: 'auto',
   showLeading: true,
   showLeadingMedia: false,
   showTrailing: true,

--- a/src/components/common/AdvancedListItemV2/style.scss
+++ b/src/components/common/AdvancedListItemV2/style.scss
@@ -33,6 +33,15 @@
     width: 100%;
   }
 
+  &__start {
+    align-items: center;
+    align-self: center;
+    display: flex;
+    flex-shrink: 0;
+    gap: spacing-v2.rc-spacing-v2('list-item-gap-v2');
+    min-width: 0;
+  }
+
   &__leading {
     align-items: center;
     align-self: center;
@@ -220,6 +229,81 @@
 
     .rc-ses-advanced-list-item-v2__leading {
       pointer-events: none;
+    }
+  }
+
+  // Wrap: auto — default horizontal layout (existing behaviour)
+
+  // Wrap: off — horizontal; title single line + ellipsis (narrow tiles)
+  &--wrap-off {
+    .rc-ses-advanced-list-item-v2__title-row {
+      flex-wrap: nowrap;
+    }
+
+    .rc-ses-advanced-list-item-v2__title {
+      display: block;
+      flex-wrap: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+
+  // Wrap: stacked — top row: Leading/Media + Trailing (centered); Content full width below.
+  // Trailing may wrap its own actions; the trailing block stays on the top row.
+  &--wrap-stacked {
+    .rc-ses-advanced-list-item-v2__body {
+      align-items: center;
+      display: grid;
+      grid-template-areas:
+        'start trailing'
+        'content content';
+      // start = intrinsic; trailing column gets remaining space (actions align end, may wrap)
+      grid-template-columns: auto minmax(0, 1fr);
+      column-gap: spacing-v2.rc-spacing-v2('list-item-gap-v2');
+      row-gap: spacing-v2.rc-spacing-v2('list-item-gap-v2');
+    }
+
+    .rc-ses-advanced-list-item-v2__start {
+      align-self: center;
+      grid-area: start;
+    }
+
+    .rc-ses-advanced-list-item-v2__trailing {
+      align-self: center;
+      flex: 0 1 auto;
+      flex-wrap: wrap;
+      grid-area: trailing;
+      justify-content: flex-end;
+      justify-self: end;
+      max-width: 100%;
+      min-width: 0;
+    }
+
+    .rc-ses-advanced-list-item-v2__content {
+      flex: none;
+      grid-area: content;
+      width: 100%;
+    }
+
+    &.rc-ses-advanced-list-item-v2--no-start .rc-ses-advanced-list-item-v2__body {
+      grid-template-areas:
+        'trailing'
+        'content';
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    &.rc-ses-advanced-list-item-v2--no-trailing .rc-ses-advanced-list-item-v2__body {
+      grid-template-areas:
+        'start'
+        'content';
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    &.rc-ses-advanced-list-item-v2--no-start.rc-ses-advanced-list-item-v2--no-trailing
+      .rc-ses-advanced-list-item-v2__body {
+      grid-template-areas: 'content';
+      grid-template-columns: minmax(0, 1fr);
     }
   }
 }

--- a/src/components/common/AdvancedListItemV2/types.ts
+++ b/src/components/common/AdvancedListItemV2/types.ts
@@ -1,8 +1,21 @@
 export type AdvancedListItemContainer = 'card' | 'row'
 
+/**
+ * Layout axis for item slots (prop, not a breakpoint).
+ * - auto: existing horizontal row (back-compat default)
+ * - off: horizontal; title clamped to one line with ellipsis (narrow tiles)
+ * - stacked: top row Leading/Media + Trailing; Content full-width below (mobile)
+ */
+export type AdvancedListItemWrap = 'auto' | 'off' | 'stacked'
+
 export type AdvancedListItemProps = {
   /** Card = bordered tile; Row = divider list row */
   container?: AdvancedListItemContainer
+  /**
+   * Slot layout. Auto = current behaviour; Off = single-line title;
+   * Stacked = mobile row (actions/status on top, content below).
+   */
+  wrap?: AdvancedListItemWrap
   title: string
   subtitle?: string
   showLeading?: boolean

--- a/src/stories/components v2/AdvancedListItem/AdvancedListItem.stories.ts
+++ b/src/stories/components v2/AdvancedListItem/AdvancedListItem.stories.ts
@@ -22,6 +22,12 @@ const meta: Meta<typeof RcSesAdvancedListItemV2> = {
       options: ['card', 'row'],
       description: 'Card = bordered tile; Row = divider list row',
     },
+    wrap: {
+      control: 'select',
+      options: ['auto', 'off', 'stacked'],
+      description:
+        'Layout axis (prop, not breakpoint). Auto = horizontal back-compat; Off = single-line title + ellipsis; Stacked = mobile (trailing on top, content below).',
+    },
     title: { control: 'text' },
     subtitle: { control: 'text' },
     showLeading: {
@@ -126,6 +132,7 @@ export const Default: Story = (args) => ({
 })
 Default.args = {
   container: 'card',
+  wrap: 'auto',
   title: 'Item title',
   subtitle: 'Supporting subtitle',
   showLeading: true,
@@ -439,6 +446,149 @@ export const WithSlots: Story = () => ({
               Optional description slot content.
             </RcSesAdvancedListItemV2>
           </RcSesAdvancedListV2>
+        </div>
+      </div>
+    </div>
+  `,
+})
+
+export const Wrap: Story = () => ({
+  components: {
+    RcSesAdvancedListV2,
+    RcSesAdvancedListItemV2,
+    RcSesButtonV2,
+    RcSesBadgeV2,
+    RcSesCheckboxV2,
+  },
+  template: `
+    <div class="storybook-field">
+      <div class="storybook-field-view">
+        <div class="advanced-list-story" style="display: flex; flex-direction: column; gap: 24px;">
+          <div>
+            <p class="text-body-small-v2" style="margin-bottom: 8px;">
+              Auto — default horizontal layout (back-compat)
+            </p>
+            <RcSesAdvancedListV2 accessible-label="Wrap auto">
+              <RcSesAdvancedListItemV2
+                wrap="auto"
+                title="Option A1"
+                subtitle="Supporting detail A1"
+                :show-meta="false"
+                :show-badge="false"
+                :show-expanded="false"
+              >
+                <template #trailing>
+                  <RcSesButtonV2 variant="link" size="small" prepend-icon="$notePencil">Edit</RcSesButtonV2>
+                  <RcSesButtonV2 variant="link" size="small" prepend-icon="$trash">Remove</RcSesButtonV2>
+                </template>
+              </RcSesAdvancedListItemV2>
+            </RcSesAdvancedListV2>
+          </div>
+
+          <div style="max-width: 220px;">
+            <p class="text-body-small-v2" style="margin-bottom: 8px;">
+              Off — narrow tile; title single line + ellipsis
+            </p>
+            <RcSesAdvancedListV2 accessible-label="Wrap off">
+              <RcSesAdvancedListItemV2
+                wrap="off"
+                title="Very long option title that should truncate with an ellipsis"
+                subtitle="Supporting detail B1"
+                :show-leading="false"
+                :show-trailing="false"
+                :show-meta="false"
+                :show-badge="false"
+                :show-expanded="false"
+              />
+            </RcSesAdvancedListV2>
+          </div>
+
+          <div style="max-width: 375px;">
+            <p class="text-body-small-v2" style="margin-bottom: 8px;">
+              Stacked — mobile (trailing top-right; content full width below). Practical min ~250px with two actions.
+            </p>
+            <RcSesAdvancedListV2 accessible-label="Wrap stacked">
+              <RcSesAdvancedListItemV2
+                wrap="stacked"
+                title="Option C1"
+                subtitle="Supporting detail C1"
+                :show-meta="false"
+                :show-badge="false"
+                :show-expanded="false"
+              >
+                <template #trailing>
+                  <RcSesButtonV2 variant="link" size="small" prepend-icon="$notePencil">Edit</RcSesButtonV2>
+                  <RcSesButtonV2 variant="link" size="small" prepend-icon="$trash">Remove</RcSesButtonV2>
+                </template>
+              </RcSesAdvancedListItemV2>
+
+              <RcSesAdvancedListItemV2
+                wrap="stacked"
+                title="Option C2"
+                subtitle="Supporting detail C2"
+                :show-meta="false"
+                :show-badge="false"
+                :show-expanded="false"
+              >
+                <template #trailing>
+                  <RcSesBadgeV2 type="warning" size="small">Pending</RcSesBadgeV2>
+                </template>
+              </RcSesAdvancedListItemV2>
+
+              <RcSesAdvancedListItemV2
+                wrap="stacked"
+                title="Option C3"
+                subtitle="Supporting detail C3"
+                selectable
+                selected
+                :show-meta="false"
+                :show-badge="false"
+                :show-trailing="false"
+                :show-expanded="false"
+              >
+                <template #leading>
+                  <RcSesCheckboxV2
+                    :model-value="true"
+                    :show-label="false"
+                    accessible-label="Option C3"
+                  />
+                </template>
+              </RcSesAdvancedListItemV2>
+
+              <RcSesAdvancedListItemV2
+                wrap="stacked"
+                title="Option C4 with slots"
+                subtitle="Supporting detail C4"
+                show-leading-media
+                show-badge
+                show-meta
+                :show-expanded="true"
+              >
+                <template #leading>
+                  <RcSesButtonV2 variant="link" size="small" icon="$caretUp" accessible-label="Move up" />
+                  <RcSesButtonV2 variant="link" size="small" icon="$caretDown" accessible-label="Move down" />
+                </template>
+                <template #leading-media>
+                  <span style="font-weight: 600;">AB</span>
+                </template>
+                <template #badge>
+                  <RcSesBadgeV2 type="info" size="small">Label</RcSesBadgeV2>
+                </template>
+                <template #meta>
+                  <span class="text-body-caption-v2">Meta one</span>
+                  <span class="text-body-caption-v2">Meta two</span>
+                </template>
+                <template #trailing>
+                  <RcSesButtonV2 variant="link" size="small" prepend-icon="$notePencil">Edit</RcSesButtonV2>
+                  <RcSesButtonV2 variant="link" size="small" prepend-icon="$trash">Remove</RcSesButtonV2>
+                </template>
+                <template #expanded>
+                  Optional expanded panel content.
+                </template>
+                Optional description slot content.
+              </RcSesAdvancedListItemV2>
+            </RcSesAdvancedListV2>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 🔗 Task
https://jira.registrucentras.lt/jira/browse/IRM-5294

@tomas562  @saukaite 

## 🧾 Summary

Adds wrap to RcSesAdvancedListItemV2 — layout axis (auto / off / stacked), not a breakpoint. Auto keeps the existing horizontal layout (back-compat default); Off clamps the title to one line with ellipsis for narrow tiles; Stacked is the mobile layout (Leading/Media + Trailing on top, content full-width below; trailing actions may wrap). Styling uses v2 tokens. Includes Storybook Wrap examples and unit tests.

## 📸 Screenshots

<img width="715" height="262" alt="image" src="https://github.com/user-attachments/assets/3db7dbd5-b336-47c5-aa08-083dfb0736dd" />
<img width="427" height="695" alt="image" src="https://github.com/user-attachments/assets/51d30943-6fb1-4b2e-8e85-4d48e74e7d59" />



## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [x] UI matches approved design (Figma)
* [x] Accessibility reviewed (keyboard navigation, labels, semantics)
