### PR TITLE
IRM-5386 (ErrorSummaryV2)

### DIFF
--- a/src/components/common/ErrorSummaryV2/RcSesErrorSummaryV2.test.ts
+++ b/src/components/common/ErrorSummaryV2/RcSesErrorSummaryV2.test.ts
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
+import { mount } from '@vue/test-utils'
 import I18NextVue from 'i18next-vue'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, afterEach } from 'vitest'
 import { nextTick } from 'vue'
 
 import initI18n from '@/plugins/i18n'
@@ -10,21 +11,37 @@ import type { ErrorSummaryProps } from './types'
 
 const { i18next } = initI18n()
 
+const globalMountOptions = {
+  plugins: [[I18NextVue, { i18next }]],
+  stubs: {
+    'v-icon': true,
+  },
+}
+
 const renderSummary = (props: Partial<ErrorSummaryProps> = {}) =>
   render(RcSesErrorSummaryV2, {
     props: {
       autofocus: false,
       ...props,
     },
-    global: {
-      plugins: [[I18NextVue, { i18next }]],
-      stubs: {
-        'v-icon': true,
-      },
+    global: globalMountOptions,
+  })
+
+const mountSummary = (props: Partial<ErrorSummaryProps> = {}) =>
+  mount(RcSesErrorSummaryV2, {
+    props: {
+      autofocus: false,
+      ...props,
     },
+    attachTo: document.body,
+    global: globalMountOptions,
   })
 
 describe('RcSesErrorSummaryV2', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
   it('renders nothing when there are no errors', () => {
     const { container } = renderSummary({ errors: [] })
 
@@ -32,14 +49,17 @@ describe('RcSesErrorSummaryV2', () => {
   })
 
   it('renders the default title and error messages', () => {
-    renderSummary({
+    const { container } = renderSummary({
       errors: [
         { message: 'Vardas, pavardė — privaloma', fieldId: 'fullName' },
         'Serverio klaida — bandykite dar kartą',
       ],
     })
 
-    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(container.querySelector('.rc-ses-error-summary-v2')).toBeInTheDocument()
+    expect(container.querySelector('.rc-ses-error-summary-v2')).toHaveAttribute(
+      'aria-labelledby',
+    )
     expect(
       screen.getByRole('heading', { name: 'Pataisykite šias klaidas' }),
     ).toBeInTheDocument()
@@ -70,9 +90,34 @@ describe('RcSesErrorSummaryV2', () => {
     expect(screen.getByRole('heading', { name: 'Yra klaidų' })).toBeInTheDocument()
   })
 
+  it('drops empty and whitespace-only messages', () => {
+    renderSummary({
+      errors: ['', '   ', { message: '   ' }, { message: 'Validi klaida' }],
+    })
+
+    expect(screen.getByText('Validi klaida')).toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
+  it('trims fieldId and treats blank fieldId as plain text', () => {
+    renderSummary({
+      errors: [
+        { message: 'El. paštas — neteisingas', fieldId: '  email  ' },
+        { message: 'Bendroji klaida', fieldId: '   ' },
+      ],
+    })
+
+    expect(
+      screen.getByRole('link', { name: 'El. paštas — neteisingas' }),
+    ).toHaveAttribute('href', '#email')
+    expect(screen.getByText('Bendroji klaida')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Bendroji klaida' })).not.toBeInTheDocument()
+  })
+
   it('focuses the linked field when an error link is clicked', async () => {
     const field = document.createElement('input')
     field.id = 'email'
+    field.scrollIntoView = vi.fn()
     document.body.appendChild(field)
     const focusSpy = vi.spyOn(field, 'focus')
 
@@ -85,22 +130,96 @@ describe('RcSesErrorSummaryV2', () => {
     )
     await nextTick()
 
-    expect(focusSpy).toHaveBeenCalled()
-    field.remove()
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+    expect(field.scrollIntoView).toHaveBeenCalledWith({
+      block: 'center',
+      behavior: 'smooth',
+    })
   })
 
-  it('exposes focus() to move keyboard focus onto the summary', async () => {
-    const { container } = renderSummary({
+  it('prevents hash navigation when the target field is missing', async () => {
+    renderSummary({
+      errors: [{ message: 'Trūkstamas laukas', fieldId: 'missing-field' }],
+    })
+
+    const link = screen.getByRole('link', { name: 'Trūkstamas laukas' })
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+    link.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('exposes focus() that moves keyboard focus onto the summary', async () => {
+    const wrapper = mountSummary({
       errors: ['Klaida'],
     })
 
-    const summary = container.querySelector('.rc-ses-error-summary-v2') as HTMLElement
+    const summary = wrapper.find('.rc-ses-error-summary-v2').element as HTMLElement
     const focusSpy = vi.spyOn(summary, 'focus')
 
-    // Access exposed method via the Vue instance on the container's first child vnode is awkward;
-    // instead assert tabindex and call focus on the root element (same as expose).
     expect(summary).toHaveAttribute('tabindex', '-1')
-    summary.focus()
-    expect(focusSpy).toHaveBeenCalled()
+    await wrapper.vm.focus()
+
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+  })
+
+  it('focuses the summary when errors appear and autofocus is true', async () => {
+    const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')
+    const wrapper = mountSummary({
+      autofocus: true,
+      errors: [],
+    })
+
+    expect(wrapper.find('.rc-ses-error-summary-v2').exists()).toBe(false)
+    focusSpy.mockClear()
+
+    await wrapper.setProps({
+      errors: ['Pirma klaida'],
+    })
+    await nextTick()
+    await nextTick()
+
+    expect(wrapper.find('.rc-ses-error-summary-v2').exists()).toBe(true)
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+    focusSpy.mockRestore()
+  })
+
+  it('does not steal focus when autofocus is false', async () => {
+    const focusSpy = vi.spyOn(HTMLElement.prototype, 'focus')
+    const wrapper = mountSummary({
+      autofocus: false,
+      errors: [],
+    })
+    focusSpy.mockClear()
+
+    await wrapper.setProps({
+      errors: ['Pirma klaida'],
+    })
+    await nextTick()
+    await nextTick()
+
+    expect(focusSpy).not.toHaveBeenCalledWith({ preventScroll: true })
+    focusSpy.mockRestore()
+  })
+
+  it('does not re-focus when errors change while already visible', async () => {
+    const wrapper = mountSummary({
+      autofocus: true,
+      errors: ['Pirma klaida'],
+    })
+    await nextTick()
+    await nextTick()
+
+    const summary = wrapper.find('.rc-ses-error-summary-v2').element as HTMLElement
+    const focusSpy = vi.spyOn(summary, 'focus')
+    focusSpy.mockClear()
+
+    await wrapper.setProps({
+      errors: ['Pirma klaida', 'Antra klaida'],
+    })
+    await nextTick()
+    await nextTick()
+
+    expect(focusSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/components/common/ErrorSummaryV2/RcSesErrorSummaryV2.test.ts
+++ b/src/components/common/ErrorSummaryV2/RcSesErrorSummaryV2.test.ts
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from '@testing-library/vue'
+import I18NextVue from 'i18next-vue'
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+import initI18n from '@/plugins/i18n'
+
+import RcSesErrorSummaryV2 from './RcSesErrorSummaryV2.vue'
+import type { ErrorSummaryProps } from './types'
+
+const { i18next } = initI18n()
+
+const renderSummary = (props: Partial<ErrorSummaryProps> = {}) =>
+  render(RcSesErrorSummaryV2, {
+    props: {
+      autofocus: false,
+      ...props,
+    },
+    global: {
+      plugins: [[I18NextVue, { i18next }]],
+      stubs: {
+        'v-icon': true,
+      },
+    },
+  })
+
+describe('RcSesErrorSummaryV2', () => {
+  it('renders nothing when there are no errors', () => {
+    const { container } = renderSummary({ errors: [] })
+
+    expect(container.querySelector('.rc-ses-error-summary-v2')).not.toBeInTheDocument()
+  })
+
+  it('renders the default title and error messages', () => {
+    renderSummary({
+      errors: [
+        { message: 'Vardas, pavardė — privaloma', fieldId: 'fullName' },
+        'Serverio klaida — bandykite dar kartą',
+      ],
+    })
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Pataisykite šias klaidas' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: 'Vardas, pavardė — privaloma' }),
+    ).toHaveAttribute('href', '#fullName')
+    expect(screen.getByText('Serverio klaida — bandykite dar kartą')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'Serverio klaida — bandykite dar kartą' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('accepts plain string errors without field links', () => {
+    renderSummary({
+      errors: ['Bendroji klaida'],
+    })
+
+    expect(screen.getByText('Bendroji klaida')).toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
+  it('uses a custom title when provided', () => {
+    renderSummary({
+      title: 'Yra klaidų',
+      errors: ['Klaida'],
+    })
+
+    expect(screen.getByRole('heading', { name: 'Yra klaidų' })).toBeInTheDocument()
+  })
+
+  it('focuses the linked field when an error link is clicked', async () => {
+    const field = document.createElement('input')
+    field.id = 'email'
+    document.body.appendChild(field)
+    const focusSpy = vi.spyOn(field, 'focus')
+
+    renderSummary({
+      errors: [{ message: 'El. paštas — neteisingo formato', fieldId: 'email' }],
+    })
+
+    await fireEvent.click(
+      screen.getByRole('link', { name: 'El. paštas — neteisingo formato' }),
+    )
+    await nextTick()
+
+    expect(focusSpy).toHaveBeenCalled()
+    field.remove()
+  })
+
+  it('exposes focus() to move keyboard focus onto the summary', async () => {
+    const { container } = renderSummary({
+      errors: ['Klaida'],
+    })
+
+    const summary = container.querySelector('.rc-ses-error-summary-v2') as HTMLElement
+    const focusSpy = vi.spyOn(summary, 'focus')
+
+    // Access exposed method via the Vue instance on the container's first child vnode is awkward;
+    // instead assert tabindex and call focus on the root element (same as expose).
+    expect(summary).toHaveAttribute('tabindex', '-1')
+    summary.focus()
+    expect(focusSpy).toHaveBeenCalled()
+  })
+})

--- a/src/components/common/ErrorSummaryV2/RcSesErrorSummaryV2.test.ts
+++ b/src/components/common/ErrorSummaryV2/RcSesErrorSummaryV2.test.ts
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/vue'
 import { mount } from '@vue/test-utils'
 import I18NextVue from 'i18next-vue'
-import { describe, expect, it, vi, afterEach } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 
 import initI18n from '@/plugins/i18n'
@@ -111,7 +111,9 @@ describe('RcSesErrorSummaryV2', () => {
       screen.getByRole('link', { name: 'El. paštas — neteisingas' }),
     ).toHaveAttribute('href', '#email')
     expect(screen.getByText('Bendroji klaida')).toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: 'Bendroji klaida' })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: 'Bendroji klaida' }),
+    ).not.toBeInTheDocument()
   })
 
   it('focuses the linked field when an error link is clicked', async () => {

--- a/src/components/common/ErrorSummaryV2/RcSesErrorSummaryV2.vue
+++ b/src/components/common/ErrorSummaryV2/RcSesErrorSummaryV2.vue
@@ -1,0 +1,127 @@
+<template>
+  <div
+    v-if="normalizedErrors.length > 0"
+    :id="rootId"
+    ref="rootRef"
+    class="rc-ses-error-summary-v2"
+    role="alert"
+    aria-live="assertive"
+    tabindex="-1"
+    :aria-labelledby="titleId"
+  >
+    <div class="rc-ses-error-summary-v2__header">
+      <v-icon
+        class="rc-ses-error-summary-v2__icon"
+        icon="$warningCircleFilled"
+        aria-hidden="true"
+      />
+      <h2 :id="titleId" class="rc-ses-error-summary-v2__title">
+        {{ titleText }}
+      </h2>
+    </div>
+
+    <ul class="rc-ses-error-summary-v2__list">
+      <li
+        v-for="(error, index) in normalizedErrors"
+        :key="error.id ?? `${error.fieldId ?? 'error'}-${index}`"
+        class="rc-ses-error-summary-v2__item"
+      >
+        <a
+          v-if="error.fieldId"
+          class="rc-ses-error-summary-v2__link"
+          :href="`#${error.fieldId}`"
+          @click="onErrorClick($event, error.fieldId)"
+        >
+          {{ error.message }}
+        </a>
+        <span v-else class="rc-ses-error-summary-v2__text">
+          {{ error.message }}
+        </span>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useTranslation } from 'i18next-vue'
+import { v4 as uuidv4 } from 'uuid'
+import { computed, nextTick, ref, watch } from 'vue'
+
+import errorSummaryV2Defaults from '@/components/common/ErrorSummaryV2/defaults'
+import type {
+  ErrorSummaryItem,
+  ErrorSummaryProps,
+} from '@/components/common/ErrorSummaryV2/types'
+
+import './style.scss'
+
+const props = withDefaults(defineProps<ErrorSummaryProps>(), errorSummaryV2Defaults)
+
+const { t } = useTranslation()
+
+const rootRef = ref<HTMLElement | null>(null)
+const generatedId = uuidv4()
+const rootId = computed(() => `rc-ses-error-summary-v2-${generatedId}`)
+const titleId = computed(() => `${rootId.value}-title`)
+
+const titleText = computed(
+  () => props.title ?? t('RcSesErrorSummaryV2.title', { ns: 'components' }),
+)
+
+const normalizedErrors = computed<ErrorSummaryItem[]>(() =>
+  (props.errors ?? [])
+    .map((error) => {
+      if (typeof error === 'string') {
+        const message = error.trim()
+        return message ? { message } : null
+      }
+
+      const message = error.message?.trim()
+      if (!message) {
+        return null
+      }
+
+      return {
+        message,
+        fieldId: error.fieldId?.trim() || undefined,
+        id: error.id,
+      }
+    })
+    .filter((error): error is ErrorSummaryItem => error != null),
+)
+
+const focus = async () => {
+  await nextTick()
+  rootRef.value?.focus({ preventScroll: true })
+  rootRef.value?.scrollIntoView?.({ block: 'nearest', behavior: 'smooth' })
+}
+
+const onErrorClick = (event: MouseEvent, fieldId: string) => {
+  const target = document.getElementById(fieldId)
+  if (!target) {
+    return
+  }
+
+  event.preventDefault()
+  target.focus()
+  target.scrollIntoView?.({ block: 'center', behavior: 'smooth' })
+}
+
+watch(
+  () => normalizedErrors.value.length,
+  async (count, previousCount) => {
+    if (!props.autofocus || count === 0) {
+      return
+    }
+
+    if ((previousCount ?? 0) === 0) {
+      await focus()
+    }
+  },
+  { immediate: true },
+)
+
+defineExpose({
+  focus,
+})
+</script>

--- a/src/components/common/ErrorSummaryV2/RcSesErrorSummaryV2.vue
+++ b/src/components/common/ErrorSummaryV2/RcSesErrorSummaryV2.vue
@@ -4,8 +4,6 @@
     :id="rootId"
     ref="rootRef"
     class="rc-ses-error-summary-v2"
-    role="alert"
-    aria-live="assertive"
     tabindex="-1"
     :aria-labelledby="titleId"
   >
@@ -97,14 +95,15 @@ const focus = async () => {
 }
 
 const onErrorClick = (event: MouseEvent, fieldId: string) => {
+  event.preventDefault()
+
   const target = document.getElementById(fieldId)
   if (!target) {
     return
   }
 
-  event.preventDefault()
-  target.focus()
-  target.scrollIntoView?.({ block: 'center', behavior: 'smooth' })
+  target.focus({ preventScroll: true })
+  target.scrollIntoView({ block: 'center', behavior: 'smooth' })
 }
 
 watch(

--- a/src/components/common/ErrorSummaryV2/defaults.ts
+++ b/src/components/common/ErrorSummaryV2/defaults.ts
@@ -1,0 +1,13 @@
+import type { ErrorSummaryError } from '@/components/common/ErrorSummaryV2/types'
+
+export type ErrorSummaryDefaultsType = {
+  errors: () => ErrorSummaryError[]
+  autofocus: boolean
+}
+
+const errorSummaryV2Defaults = {
+  errors: (): ErrorSummaryError[] => [],
+  autofocus: true,
+} satisfies ErrorSummaryDefaultsType
+
+export default errorSummaryV2Defaults

--- a/src/components/common/ErrorSummaryV2/defaults.ts
+++ b/src/components/common/ErrorSummaryV2/defaults.ts
@@ -1,13 +1,8 @@
 import type { ErrorSummaryError } from '@/components/common/ErrorSummaryV2/types'
 
-export type ErrorSummaryDefaultsType = {
-  errors: () => ErrorSummaryError[]
-  autofocus: boolean
-}
-
 const errorSummaryV2Defaults = {
   errors: (): ErrorSummaryError[] => [],
   autofocus: true,
-} satisfies ErrorSummaryDefaultsType
+}
 
 export default errorSummaryV2Defaults

--- a/src/components/common/ErrorSummaryV2/style.scss
+++ b/src/components/common/ErrorSummaryV2/style.scss
@@ -1,0 +1,98 @@
+@use '/src/styles/vuetify/borders-v2' as borders-v2;
+@use '/src/styles/vuetify/sizes-v2' as sizes-v2;
+@use '/src/styles/vuetify/spacing-v2' as spacing-v2;
+@use '/src/styles/vuetify/typography-v2' as typography-v2;
+
+.rc-ses-error-summary-v2 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: spacing-v2.rc-spacing-v2('spacing-12-v2');
+  width: 100%;
+  padding: spacing-v2.rc-spacing-v2('spacing-16-v2');
+  background-color: rgb(var(--v-theme-red-100-v2));
+  border: borders-v2.rc-stroke-v2('border-width-default-v2') solid
+    rgb(var(--v-theme-error-border-v2));
+  border-radius: borders-v2.rc-radius-v2('radius-12-v2');
+  color: rgb(var(--v-theme-error-text-v2));
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgb(var(--v-theme-border-focus-actual-v2));
+    outline-offset: 2px;
+  }
+
+  &__header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: spacing-v2.rc-spacing-v2('spacing-8-v2');
+    align-self: stretch;
+  }
+
+  &__icon {
+    flex-shrink: 0;
+    color: rgb(var(--v-theme-error-text-v2));
+
+    @include sizes-v2.rc-icon-size-v2('icon-medium-v2');
+  }
+
+  &__title {
+    @include typography-v2.rc-typography-v2('body-large-v2');
+
+    flex: 1 1 auto;
+    margin: 0;
+    min-width: 0;
+    font-weight: 600;
+    line-height: 1.375rem;
+    color: rgb(var(--v-theme-error-text-v2));
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: spacing-v2.rc-spacing-v2('spacing-8-v2');
+    align-self: stretch;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__item {
+    align-self: stretch;
+    margin: 0;
+  }
+
+  &__link,
+  &__text {
+    @include typography-v2.rc-typography-v2('body-regular-v2');
+
+    display: block;
+    overflow-wrap: break-word;
+  }
+
+  &__link {
+    color: rgb(var(--v-theme-text-link-v2));
+    text-decoration: underline;
+    text-underline-offset: 2px;
+
+    &:hover {
+      color: rgb(var(--v-theme-text-link-hover-v2));
+    }
+
+    &:focus-visible {
+      outline: 2px solid rgb(var(--v-theme-border-focus-actual-v2));
+      outline-offset: 2px;
+      border-radius: borders-v2.rc-radius-v2('radius-4-v2');
+    }
+  }
+
+  &__text {
+    color: rgb(var(--v-theme-error-text-v2));
+  }
+}

--- a/src/components/common/ErrorSummaryV2/types.ts
+++ b/src/components/common/ErrorSummaryV2/types.ts
@@ -1,0 +1,13 @@
+export type ErrorSummaryItem = {
+  message: string
+  fieldId?: string
+  id?: string
+}
+
+export type ErrorSummaryError = ErrorSummaryItem | string
+
+export type ErrorSummaryProps = {
+  errors?: ErrorSummaryError[]
+  title?: string
+  autofocus?: boolean
+}

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -13,6 +13,7 @@ import RcSesChipSelectV2 from '@/components/common/ChipSelectV2/RcSesChipSelectV
 import RcSesDatePickerV2 from '@/components/common/DatePickerV2/RcSesDatePickerV2.vue'
 import RcSesDropdownV2 from '@/components/common/DropdownV2/RcSesDropdownV2.vue'
 import RcSesError from '@/components/common/Error/RcSesError.vue'
+import RcSesErrorSummaryV2 from '@/components/common/ErrorSummaryV2/RcSesErrorSummaryV2.vue'
 import RcSesFilterDropdownV2 from '@/components/common/FilterDropdownV2/RcSesFilterDropdownV2.vue'
 import RcSesFiltersV2 from '@/components/common/FiltersV2/RcSesFiltersV2.vue'
 import RcSesFullPageLoaderV2 from '@/components/common/FullPageLoaderV2/RcSesFullPageLoaderV2.vue'
@@ -165,6 +166,7 @@ export function createRcSesComponents(options: object = {}): Plugin<[]> {
     app.component('RcSesImageAndTextV2', RcSesImageAndTextV2)
     app.component('RcSesSnackbarV2', RcSesSnackbarV2)
     app.component('RcSesInlineAlertV2', RcSesInlineAlertV2)
+    app.component('RcSesErrorSummaryV2', RcSesErrorSummaryV2)
     app.component('RcSesLoaderV2', RcSesLoaderV2)
     app.component('RcSesFullPageLoaderV2', RcSesFullPageLoaderV2)
     app.component('RcSesStepperV2', RcSesStepperV2)
@@ -196,7 +198,7 @@ export { RcSesBadgeV2, RcSesButtonV2, RcSesToggleV2 }
 export { RcSesAdvancedListV2, RcSesAdvancedListItemV2 }
 export { RcSesRadioGroupV2, RcSesRadioV2, RcSesRadioSelectableAreaV2 }
 export { RcSesImageAndTextV2, RcSesSnackbarV2 }
-export { RcSesInlineAlertV2, RcSesStepperV2 }
+export { RcSesInlineAlertV2, RcSesErrorSummaryV2, RcSesStepperV2 }
 export { RcSesCheckboxV2, RcSesCheckboxSelectableAreaV2 }
 export { RcSesChipSelectV2 }
 export { RcSesFilterDropdownV2, RcSesFiltersV2 }

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -52,6 +52,10 @@ const i18n = () => {
             close: 'Uždaryti',
           },
 
+          RcSesErrorSummaryV2: {
+            title: 'Pataisykite šias klaidas',
+          },
+
           RcSesRadioV2: {
             loading: 'Kraunama...',
           },
@@ -172,6 +176,10 @@ const i18n = () => {
           },
           RcSesInlineAlertV2: {
             close: 'Close',
+          },
+
+          RcSesErrorSummaryV2: {
+            title: 'Fix these errors',
           },
 
           RcSesRadioV2: {

--- a/src/stories/components v2/ErrorSummary/ErrorSummary.stories.ts
+++ b/src/stories/components v2/ErrorSummary/ErrorSummary.stories.ts
@@ -1,0 +1,220 @@
+import type { Meta, StoryFn } from '@storybook/vue3'
+import { computed, ref } from 'vue'
+
+import RcSesErrorSummaryV2 from '@/components/common/ErrorSummaryV2/RcSesErrorSummaryV2.vue'
+import type { ErrorSummaryError } from '@/components/common/ErrorSummaryV2/types'
+import RcSesButtonV2 from '@/components/common/buttonV2/RcSesButtonV2.vue'
+import RcSesCheckboxV2 from '@/components/common/inputs/Checkboxes/CheckboxV2/RcSesCheckboxV2.vue'
+import RcSesInputV2 from '@/components/common/inputs/InputV2/RcSesInputV2.vue'
+
+const defaultTitle = 'Fix these errors'
+
+const sampleErrors: ErrorSummaryError[] = [
+  { message: 'Full name — required', fieldId: 'fullName' },
+  { message: 'Email — invalid format', fieldId: 'email' },
+  { message: 'Consent — must be checked', fieldId: 'consent' },
+]
+
+const meta: Meta<typeof RcSesErrorSummaryV2> = {
+  title: 'componentsV2/ErrorSummary',
+  component: RcSesErrorSummaryV2,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Heading text. Pass via prop (not hardcoded in the component).',
+    },
+    autofocus: {
+      control: 'boolean',
+      description: 'Move focus to the summary when errors first appear.',
+    },
+    errors: {
+      control: 'object',
+      description:
+        'Array of `{ message, fieldId? }` objects and/or plain strings (no field link).',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryFn<typeof RcSesErrorSummaryV2>
+
+export const Default: Story = (args) => ({
+  components: { RcSesErrorSummaryV2 },
+  setup() {
+    return { args }
+  },
+  template: `
+    <div style="max-width: 520px;">
+      <RcSesErrorSummaryV2 v-bind="args" />
+    </div>
+  `,
+})
+Default.args = {
+  title: defaultTitle,
+  autofocus: false,
+  errors: sampleErrors,
+}
+
+export const MixedFieldAndText: Story = () => ({
+  components: { RcSesErrorSummaryV2 },
+  template: `
+    <div style="max-width: 520px;">
+      <RcSesErrorSummaryV2
+        title="Fix these errors"
+        :autofocus="false"
+        :errors="[
+          { message: 'Full name — required', fieldId: 'fullName' },
+          'Something went wrong — please try again',
+        ]"
+      />
+    </div>
+  `,
+})
+
+export const FormExample: Story = () => ({
+  components: {
+    RcSesErrorSummaryV2,
+    RcSesInputV2,
+    RcSesCheckboxV2,
+    RcSesButtonV2,
+  },
+  setup() {
+    const fullName = ref('')
+    const email = ref('')
+    const consent = ref(false)
+    const submitted = ref(false)
+    const summaryRef = ref<{ focus: () => void } | null>(null)
+
+    const fieldErrors = computed(() => {
+      const next = {
+        fullName: '',
+        email: '',
+        consent: '',
+      }
+
+      if (!submitted.value) {
+        return next
+      }
+
+      if (!fullName.value.trim()) {
+        next.fullName = 'Enter your full name'
+      }
+
+      if (!email.value.trim()) {
+        next.email = 'Enter your email'
+      } else if (!email.value.includes('@')) {
+        next.email = 'Enter a valid email'
+      }
+
+      if (!consent.value) {
+        next.consent = 'You must agree to continue'
+      }
+
+      return next
+    })
+
+    const errors = computed<ErrorSummaryError[]>(() => {
+      if (!submitted.value) {
+        return []
+      }
+
+      const next: ErrorSummaryError[] = []
+
+      if (fieldErrors.value.fullName) {
+        next.push({
+          message: `Full name — ${fieldErrors.value.fullName}`,
+          fieldId: 'story-fullName',
+        })
+      }
+
+      if (fieldErrors.value.email) {
+        next.push({
+          message: `Email — ${fieldErrors.value.email}`,
+          fieldId: 'story-email',
+        })
+      }
+
+      if (fieldErrors.value.consent) {
+        next.push({
+          message: `Consent — ${fieldErrors.value.consent}`,
+          fieldId: 'story-consent',
+        })
+      }
+
+      return next
+    })
+
+    const onSubmit = () => {
+      submitted.value = true
+
+      if (errors.value.length > 0) {
+        summaryRef.value?.focus()
+      }
+    }
+
+    return {
+      fullName,
+      email,
+      consent,
+      fieldErrors,
+      errors,
+      summaryRef,
+      onSubmit,
+    }
+  },
+  template: `
+    <div
+      style="
+        max-width: 520px;
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+        padding: 24px;
+        border: 1px solid #dce0e5;
+        border-radius: 12px;
+        background: #fff;
+      "
+    >
+      <RcSesErrorSummaryV2
+        ref="summaryRef"
+        title="Fix these errors"
+        :autofocus="true"
+        :errors="errors"
+      />
+
+      <RcSesInputV2
+        id="story-fullName"
+        v-model="fullName"
+        label="Full name"
+        placeholder="Enter full name"
+        :show-explainer="false"
+        :error="fieldErrors.fullName || false"
+      />
+
+      <RcSesInputV2
+        id="story-email"
+        v-model="email"
+        label="Email"
+        placeholder="name@example.com"
+        :show-explainer="false"
+        :error="fieldErrors.email || false"
+      />
+
+      <div id="story-consent" tabindex="-1">
+        <RcSesCheckboxV2
+          v-model="consent"
+          label="I agree to the terms of service"
+          :error="fieldErrors.consent || false"
+        />
+      </div>
+
+      <div>
+        <RcSesButtonV2 type="button" variant="primary" @click="onSubmit">
+          Continue
+        </RcSesButtonV2>
+      </div>
+    </div>
+  `,
+})


### PR DESCRIPTION
## 🔗 Task
https://jira.registrucentras.lt/jira/browse/IRM-5386

@tomas562  @saukaite 

## 🧾 Summary

Adds RcSesErrorSummaryV2 — form validation error summary (GOV.UK-style): CTA stays enabled; after submit, show all errors at the top. Accepts an errors array of { message, fieldId? } and/or plain strings (no field link). Optional title (defaults to i18n), autofocus when errors first appear, and exposed focus(). Linked items focus the target #fieldId; text-only items render without a link. Styling uses v2 tokens. Includes Storybook examples (Default, MixedFieldAndText, FormExample) and unit tests.

## 📸 Screenshots

<img width="558" height="427" alt="image" src="https://github.com/user-attachments/assets/20770d43-5db1-408c-8d13-52e2dedbb40f" />


## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [x] UI matches approved design (Figma)
* [x] Accessibility reviewed (keyboard navigation, labels, semantics)
