### PR TITLE
IRM-5419

### DIFF
--- a/src/components/common/DatePickerV2/RcSesDatePickerV2.test.ts
+++ b/src/components/common/DatePickerV2/RcSesDatePickerV2.test.ts
@@ -244,6 +244,25 @@ describe('RcSesDatePickerV2', () => {
     expect((input as HTMLInputElement).value).toBe('2026-01-15')
   })
 
+  it('does not rewrite an end-only range on blur when nothing was typed', async () => {
+    const { model } = renderPicker(
+      {
+        label: 'Date range',
+        range: true,
+        showExplainer: false,
+      },
+      [null, '2026-06-15'],
+    )
+
+    const input = screen.getByRole('textbox')
+    expect((input as HTMLInputElement).value).toBe('2026-06-15')
+
+    await fireEvent.focus(input)
+    await fireEvent.blur(input)
+
+    expect(model.value).toEqual([null, '2026-06-15'])
+  })
+
   it('accepts a manually typed range on Enter', async () => {
     const { model } = renderPicker(
       {

--- a/src/components/common/DatePickerV2/RcSesDatePickerV2.test.ts
+++ b/src/components/common/DatePickerV2/RcSesDatePickerV2.test.ts
@@ -42,6 +42,7 @@ const InputV2Stub = {
     disabled: { type: Boolean, default: false },
     showLabel: { type: Boolean, default: true },
   },
+  emits: ['update:modelValue', 'focus', 'blur', 'keydown'],
   template: `
     <div class="rc-ses-input-v2-stub">
       <label v-if="showLabel && label">{{ label }}</label>
@@ -51,7 +52,10 @@ const InputV2Stub = {
         :value="modelValue"
         :placeholder="placeholder"
         :disabled="disabled"
-        readonly
+        @input="$emit('update:modelValue', ($event.target).value)"
+        @focus="$emit('focus', $event)"
+        @blur="$emit('blur', $event)"
+        @keydown="$emit('keydown', $event)"
       />
       <slot name="trailing" />
     </div>
@@ -91,6 +95,13 @@ const renderPicker = (
   return { ...result, model }
 }
 
+const calendarButton = () =>
+  screen.getByRole('button', { name: /open calendar|atidaryti kalendorių/i })
+
+const openCalendar = async () => {
+  await fireEvent.click(calendarButton())
+}
+
 describe('RcSesDatePickerV2', () => {
   it('renders trigger label and calendar icon', () => {
     renderPicker({
@@ -111,7 +122,7 @@ describe('RcSesDatePickerV2', () => {
       null,
     )
 
-    await fireEvent.click(screen.getByRole('combobox'))
+    await openCalendar()
     expect(screen.getByRole('dialog')).toBeInTheDocument()
 
     const day = screen.getByRole('gridcell', { name: /15/i })
@@ -131,7 +142,7 @@ describe('RcSesDatePickerV2', () => {
       [null, null],
     )
 
-    await fireEvent.click(screen.getByRole('combobox'))
+    await openCalendar()
 
     const days = screen.getAllByRole('gridcell')
     const enabled = days.filter((el) => !(el as HTMLButtonElement).disabled)
@@ -152,7 +163,7 @@ describe('RcSesDatePickerV2', () => {
       showExplainer: false,
     })
 
-    await fireEvent.click(screen.getByRole('combobox'))
+    await openCalendar()
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
@@ -166,7 +177,7 @@ describe('RcSesDatePickerV2', () => {
       ['2026-06-10', null],
     )
 
-    await fireEvent.click(screen.getByRole('combobox'))
+    await openCalendar()
 
     const startDay = screen
       .getAllByRole('gridcell')
@@ -175,5 +186,141 @@ describe('RcSesDatePickerV2', () => {
     expect(startDay).toBeTruthy()
     expect(startDay?.textContent).toBe('10')
     expect(startDay?.className).toContain('rc-ses-date-picker-v2__day--range-start')
+  })
+
+  it('accepts a manually typed single date on blur', async () => {
+    const { model } = renderPicker(
+      {
+        label: 'Date',
+        showExplainer: false,
+      },
+      null,
+    )
+
+    const input = screen.getByRole('textbox')
+    await fireEvent.focus(input)
+    await fireEvent.update(input, '2026-08-20')
+    await fireEvent.blur(input)
+
+    expect(model.value).toBe('2026-08-20')
+    expect((input as HTMLInputElement).value).toBe('2026-08-20')
+  })
+
+  it('reverts invalid typed date on blur', async () => {
+    const { model } = renderPicker(
+      {
+        label: 'Date',
+        showExplainer: false,
+      },
+      '2026-01-15',
+    )
+
+    const input = screen.getByRole('textbox')
+    await fireEvent.focus(input)
+    expect((input as HTMLInputElement).value).toBe('2026-01-15')
+
+    await fireEvent.update(input, 'not-a-date')
+    await fireEvent.blur(input)
+
+    expect(model.value).toBe('2026-01-15')
+    expect((input as HTMLInputElement).value).toBe('2026-01-15')
+  })
+
+  it('rejects overflow calendar dates on blur', async () => {
+    const { model } = renderPicker(
+      {
+        label: 'Date',
+        showExplainer: false,
+      },
+      '2026-01-15',
+    )
+
+    const input = screen.getByRole('textbox')
+    await fireEvent.focus(input)
+    await fireEvent.update(input, '2026-02-31')
+    await fireEvent.blur(input)
+
+    expect(model.value).toBe('2026-01-15')
+    expect((input as HTMLInputElement).value).toBe('2026-01-15')
+  })
+
+  it('accepts a manually typed range on Enter', async () => {
+    const { model } = renderPicker(
+      {
+        label: 'Date range',
+        range: true,
+        showExplainer: false,
+      },
+      [null, null],
+    )
+
+    const input = screen.getByRole('textbox')
+    await fireEvent.focus(input)
+    await fireEvent.update(input, '2026-06-10 – 2026-06-15')
+    await fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(model.value).toEqual(['2026-06-10', '2026-06-15'])
+  })
+
+  it('clears the value when the input is emptied', async () => {
+    const { model } = renderPicker(
+      {
+        label: 'Date',
+        showExplainer: false,
+      },
+      '2026-03-01',
+    )
+
+    const input = screen.getByRole('textbox')
+    await fireEvent.focus(input)
+    await fireEvent.update(input, '')
+    await fireEvent.blur(input)
+
+    expect(model.value).toBeNull()
+  })
+
+  it('opens calendar on typed year without requiring blur commit first', async () => {
+    renderPicker(
+      {
+        label: 'Date',
+        showExplainer: false,
+      },
+      '2026-06-10',
+    )
+
+    const input = screen.getByRole('textbox')
+    const button = calendarButton()
+
+    await fireEvent.focus(input)
+    await fireEvent.update(input, '2015')
+    await fireEvent.blur(input, { relatedTarget: button })
+    await fireEvent.click(button)
+
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeInTheDocument()
+    expect(dialog.getAttribute('aria-label') ?? '').toMatch(/2015/)
+    expect((input as HTMLInputElement).value).toBe('2015')
+  })
+
+  it('keeps calendar selection when typed text differs', async () => {
+    const { model } = renderPicker(
+      {
+        label: 'Date',
+        showExplainer: false,
+      },
+      null,
+    )
+
+    const input = screen.getByRole('textbox')
+    await fireEvent.focus(input)
+    await fireEvent.update(input, '2015-08-20')
+    await fireEvent.keyDown(input, { key: 'ArrowDown' })
+
+    expect(screen.getByRole('dialog').getAttribute('aria-label') ?? '').toMatch(/2015/)
+
+    const day = screen.getByRole('gridcell', { name: /2015.*15|15.*2015/i })
+    await fireEvent.click(day)
+
+    expect(model.value).toBe('2015-08-15')
   })
 })

--- a/src/components/common/DatePickerV2/RcSesDatePickerV2.vue
+++ b/src/components/common/DatePickerV2/RcSesDatePickerV2.vue
@@ -384,7 +384,7 @@ const resolveCalendarAnchor = (value: string): Date | null => {
 }
 
 const commitTypedValue = () => {
-  if (props.disabled) {
+  if (props.disabled || inputText.value === displayValue.value) {
     return
   }
 

--- a/src/components/common/DatePickerV2/RcSesDatePickerV2.vue
+++ b/src/components/common/DatePickerV2/RcSesDatePickerV2.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="rc-ses-date-picker-v2">
+  <div ref="rootEl" class="rc-ses-date-picker-v2">
     <v-menu
       v-model="open"
       :close-on-content-click="false"
@@ -10,21 +10,10 @@
       :content-class="'rc-ses-date-picker-v2__overlay'"
     >
       <template #activator="{ props: menuProps }">
-        <div
-          v-bind="menuProps"
-          :class="triggerClasses"
-          role="combobox"
-          :aria-expanded="open"
-          :aria-controls="panelId"
-          aria-haspopup="dialog"
-          :aria-disabled="props.disabled || undefined"
-          :aria-label="triggerAriaLabel"
-          tabindex="0"
-          @keydown="onTriggerKeydown"
-        >
+        <div :class="triggerClasses">
           <RcSesInputV2
             :id="inputId"
-            :model-value="displayValue"
+            v-model="inputText"
             :label="props.label"
             :helper="props.helper"
             :error="props.error"
@@ -37,14 +26,27 @@
             :show-label="props.showLabel"
             :show-explainer="props.showExplainer"
             :show-helper="props.showHelper"
-            readonly
             :show-trailing="false"
-            tabindex="-1"
+            :aria-expanded="open"
+            :aria-controls="panelId"
+            aria-haspopup="dialog"
+            @focus="onInputFocus"
+            @blur="onInputBlur"
+            @keydown="onInputKeydown"
           >
             <template #leading>
-              <span class="rc-ses-date-picker-v2__calendar-icon" aria-hidden="true">
-                <v-icon icon="$calendar" />
-              </span>
+              <button
+                v-bind="menuProps"
+                type="button"
+                class="rc-ses-date-picker-v2__calendar-button"
+                :aria-label="openCalendarLabel"
+                :aria-expanded="open"
+                :aria-controls="panelId"
+                aria-haspopup="dialog"
+                :disabled="props.disabled || undefined"
+              >
+                <v-icon icon="$calendar" aria-hidden="true" />
+              </button>
             </template>
           </RcSesInputV2>
         </div>
@@ -131,9 +133,11 @@ import {
   format as formatDate,
   isAfter,
   isBefore,
+  isMatch,
   isSameDay,
   isToday,
   isValid,
+  parse,
   parseISO,
   startOfMonth,
   subDays,
@@ -170,10 +174,14 @@ const generatedId = uuidv4()
 const inputId = computed(() => props.id ?? generatedId)
 const panelId = computed(() => `${inputId.value}-panel`)
 
+const rootEl = ref<HTMLElement | null>(null)
 const viewDate = ref(new Date())
 const focusedIso = ref<string | null>(null)
 const hoverIso = ref<string | null>(null)
 const rangeDraftStart = ref<string | null>(null)
+const inputText = ref('')
+const inputFocused = ref(false)
+const skipCommitOnClose = ref(false)
 
 const dateFnsLocale = computed(() => (i18next.language?.startsWith('lt') ? lt : enUS))
 
@@ -190,6 +198,10 @@ const previousMonthLabel = computed(() =>
 
 const nextMonthLabel = computed(() =>
   t('RcSesDatePickerV2.nextMonth', { ns: 'components' }),
+)
+
+const openCalendarLabel = computed(() =>
+  t('RcSesDatePickerV2.openCalendar', { ns: 'components' }),
 )
 
 const placeholderText = computed(
@@ -210,18 +222,6 @@ const triggerClasses = computed(() => [
   },
 ])
 
-const triggerAriaLabel = computed(() => {
-  if (props.showLabel && props.label) {
-    return undefined
-  }
-
-  return (
-    props.accessibleLabel ??
-    props.label ??
-    t('RcSesDatePickerV2.openCalendar', { ns: 'components' })
-  )
-})
-
 const toIso = (date: Date) => formatDate(date, 'yyyy-MM-dd')
 
 const parseIso = (value: string | null | undefined): Date | null => {
@@ -231,6 +231,44 @@ const parseIso = (value: string | null | undefined): Date | null => {
 
   const parsed = parseISO(value)
   return isValid(parsed) ? parsed : null
+}
+
+const parseTypedDate = (value: string): Date | null => {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  if (isMatch(trimmed, props.format)) {
+    const parsed = parse(trimmed, props.format, new Date())
+    // Round-trip rejects overflow dates (e.g. 2026-02-31 → Mar 3).
+    if (isValid(parsed) && formatDate(parsed, props.format) === trimmed) {
+      return parsed
+    }
+  }
+
+  const isoParsed = parseISO(trimmed)
+  if (isValid(isoParsed) && toIso(isoParsed) === trimmed) {
+    return isoParsed
+  }
+
+  return null
+}
+
+const isPickerInteractionTarget = (target: EventTarget | null) => {
+  if (!(target instanceof Element)) {
+    return false
+  }
+
+  if (rootEl.value?.contains(target)) {
+    return true
+  }
+
+  // Menu content is teleported outside the root.
+  return Boolean(
+    target.closest('.rc-ses-date-picker-v2__panel') ||
+      target.closest('.rc-ses-date-picker-v2__overlay'),
+  )
 }
 
 const singleValue = computed(() => {
@@ -280,6 +318,16 @@ const displayValue = computed(() => {
   return singleValue.value ? formatDisplayDate(singleValue.value) : ''
 })
 
+watch(
+  displayValue,
+  (value) => {
+    if (!inputFocused.value) {
+      inputText.value = value
+    }
+  },
+  { immediate: true },
+)
+
 const minDateObj = computed(() => parseIso(props.minDate))
 const maxDateObj = computed(() => parseIso(props.maxDate))
 
@@ -293,6 +341,169 @@ const isDateDisabled = (date: Date) => {
   }
 
   return false
+}
+
+const splitRangeInput = (value: string) =>
+  value
+    // Prefer en/em dash or arrow; only treat ASCII "-" as a separator when spaced
+    // so ISO-like dates (yyyy-MM-dd) are not split apart.
+    .split(/\s*[–—→]\s*|\s+-\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+
+/** Resolve a calendar month/year from typed text (full date, yyyy-MM, or year). */
+const resolveCalendarAnchor = (value: string): Date | null => {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  const firstPart = props.range ? splitRangeInput(trimmed)[0] ?? trimmed : trimmed
+
+  const fullDate = parseTypedDate(firstPart)
+  if (fullDate) {
+    return fullDate
+  }
+
+  if (/^\d{4}-\d{2}$/.test(firstPart)) {
+    const yearMonth = parse(firstPart, 'yyyy-MM', new Date())
+    if (isValid(yearMonth) && formatDate(yearMonth, 'yyyy-MM') === firstPart) {
+      return yearMonth
+    }
+  }
+
+  const yearMatch = firstPart.match(/^(\d{4})\b/)
+  if (yearMatch) {
+    const year = Number(yearMatch[1])
+    if (year >= 1000 && year <= 9999) {
+      return new Date(year, viewDate.value.getMonth(), 1)
+    }
+  }
+
+  return null
+}
+
+const commitTypedValue = () => {
+  if (props.disabled) {
+    return
+  }
+
+  const raw = inputText.value.trim()
+
+  if (!raw) {
+    model.value = props.range ? [null, null] : null
+    rangeDraftStart.value = null
+    hoverIso.value = null
+    inputText.value = displayValue.value
+    return
+  }
+
+  if (props.range) {
+    const parts = splitRangeInput(raw)
+
+    if (parts.length === 1) {
+      const startDate = parseTypedDate(parts[0]!)
+      if (!startDate || isDateDisabled(startDate)) {
+        inputText.value = displayValue.value
+        return
+      }
+
+      const startIso = toIso(startDate)
+      model.value = [startIso, null]
+      rangeDraftStart.value = startIso
+      hoverIso.value = startIso
+      viewDate.value = startDate
+      inputText.value = displayValue.value
+      return
+    }
+
+    if (parts.length >= 2) {
+      const startDate = parseTypedDate(parts[0]!)
+      const endDate = parseTypedDate(parts[1]!)
+      if (
+        !startDate ||
+        !endDate ||
+        isDateDisabled(startDate) ||
+        isDateDisabled(endDate)
+      ) {
+        inputText.value = displayValue.value
+        return
+      }
+
+      const startIso = toIso(startDate)
+      const endIso = toIso(endDate)
+      model.value = isAfter(startDate, endDate) ? [endIso, startIso] : [startIso, endIso]
+      rangeDraftStart.value = null
+      hoverIso.value = null
+      viewDate.value = startDate
+      inputText.value = displayValue.value
+      return
+    }
+
+    inputText.value = displayValue.value
+    return
+  }
+
+  const date = parseTypedDate(raw)
+  if (!date || isDateDisabled(date)) {
+    inputText.value = displayValue.value
+    return
+  }
+
+  model.value = toIso(date)
+  viewDate.value = date
+  inputText.value = displayValue.value
+}
+
+const onInputFocus = () => {
+  inputFocused.value = true
+}
+
+const onInputBlur = (event: FocusEvent) => {
+  inputFocused.value = false
+
+  if (isPickerInteractionTarget(event.relatedTarget)) {
+    return
+  }
+
+  // Clicking teleported panel days often has relatedTarget=null while the menu is open.
+  if (open.value) {
+    requestAnimationFrame(() => {
+      if (open.value || isPickerInteractionTarget(document.activeElement)) {
+        return
+      }
+
+      commitTypedValue()
+    })
+    return
+  }
+
+  commitTypedValue()
+}
+
+const onInputKeydown = (event: KeyboardEvent) => {
+  if (props.disabled) {
+    return
+  }
+
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    open.value = true
+    return
+  }
+
+  if (event.key === 'Enter') {
+    event.preventDefault()
+    commitTypedValue()
+    open.value = false
+    return
+  }
+
+  if (event.key === 'Escape' && open.value) {
+    event.preventDefault()
+    open.value = false
+    inputText.value = displayValue.value
+  }
 }
 
 const calendarDays = computed((): DatePickerV2CalendarDay[] => {
@@ -450,6 +661,8 @@ const onSelectDay = (day: DatePickerV2CalendarDay) => {
 
   if (!props.range) {
     model.value = day.iso
+    inputText.value = displayValue.value
+    skipCommitOnClose.value = true
     open.value = false
     return
   }
@@ -458,6 +671,7 @@ const onSelectDay = (day: DatePickerV2CalendarDay) => {
     rangeDraftStart.value = day.iso
     hoverIso.value = day.iso
     model.value = [day.iso, null]
+    inputText.value = displayValue.value
     return
   }
 
@@ -469,6 +683,8 @@ const onSelectDay = (day: DatePickerV2CalendarDay) => {
   model.value = isAfter(startDate, endDate) ? [end, start] : [start, end]
   rangeDraftStart.value = null
   hoverIso.value = null
+  inputText.value = displayValue.value
+  skipCommitOnClose.value = true
   open.value = false
 }
 
@@ -486,22 +702,6 @@ const moveFocus = (deltaDays: number) => {
     }
 
     next = addDays(next, deltaDays > 0 ? 1 : -1)
-  }
-}
-
-const onTriggerKeydown = (event: KeyboardEvent) => {
-  if (props.disabled) {
-    return
-  }
-
-  if (event.key === 'ArrowDown' || event.key === 'Enter' || event.key === ' ') {
-    event.preventDefault()
-    open.value = true
-  }
-
-  if (event.key === 'Escape' && open.value) {
-    event.preventDefault()
-    open.value = false
   }
 }
 
@@ -554,6 +754,17 @@ watch(open, (isOpen) => {
   if (!isOpen) {
     rangeDraftStart.value = null
     hoverIso.value = null
+
+    if (skipCommitOnClose.value) {
+      skipCommitOnClose.value = false
+      inputText.value = displayValue.value
+      return
+    }
+
+    if (!inputFocused.value) {
+      commitTypedValue()
+    }
+
     return
   }
 
@@ -564,12 +775,11 @@ watch(open, (isOpen) => {
     hoverIso.value = rangeStart
   }
 
-  const anchor = singleValue.value || rangeStart || rangeEnd || toIso(new Date())
+  const fromInput = resolveCalendarAnchor(inputText.value)
+  const fromModel = parseIso(singleValue.value || rangeStart || rangeEnd || null)
+  const anchor = fromInput ?? fromModel ?? new Date()
 
-  const parsed = parseIso(anchor)
-  if (parsed) {
-    viewDate.value = parsed
-    focusDay(toIso(parsed))
-  }
+  viewDate.value = anchor
+  focusDay(toIso(anchor))
 })
 </script>

--- a/src/components/common/DatePickerV2/style.scss
+++ b/src/components/common/DatePickerV2/style.scss
@@ -12,25 +12,52 @@ $day-size: sizes-v2.rc-size-v2('size-44-v2');
   width: 100%;
 
   &__trigger {
-    cursor: pointer;
     width: 100%;
 
     .rc-ses-input-v2__field,
     .rc-ses-input-v2__control,
+    .v-field,
     .v-field__input,
     input {
-      cursor: pointer;
+      cursor: text;
     }
   }
 
   &__trigger--disabled {
     cursor: not-allowed;
+
+    .rc-ses-input-v2__field,
+    .rc-ses-input-v2__control,
+    .v-field,
+    .v-field__input,
+    input {
+      cursor: not-allowed;
+    }
   }
 
-  &__calendar-icon {
+  &__calendar-button {
+    align-items: center;
+    appearance: none;
+    background: transparent;
+    border: 0;
+    border-radius: borders-v2.rc-radius-v2('radius-4-v2');
     color: rgb(var(--v-theme-text-muted-v2));
+    cursor: pointer;
     display: inline-flex;
     line-height: 0;
+    margin: 0;
+    padding: 0;
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+
+    &:focus-visible {
+      outline: borders-v2.rc-stroke-v2('stroke-2-v2') solid
+        rgb(var(--v-theme-border-focus-actual-v2));
+      outline-offset: 2px;
+    }
 
     .v-icon {
       @include sizes-v2.rc-icon-size-v2('icon-medium-v2');

--- a/src/stories/components v2/DatePicker/DatePicker.stories.ts
+++ b/src/stories/components v2/DatePicker/DatePicker.stories.ts
@@ -17,7 +17,8 @@ const meta: Meta<typeof RcSesDatePickerV2> = {
       control: 'boolean',
     },
     format: {
-      description: 'Display format for the trigger (date-fns).',
+      description:
+        'Display and manual-entry format (date-fns). Users can type a date in this format and commit with Enter or blur.',
       control: 'text',
     },
     minDate: {


### PR DESCRIPTION
## 🔗 Task
https://jira.registrucentras.lt/jira/browse/IRM-5419

@tomas562  @saukaite 

## 🧾 Summary

Enables manual date entry in RcSesDatePickerV2: the trigger is no longer readonly. Users can type a date in the configured format (default yyyy-MM-dd) and commit with Enter or blur; invalid or overflow values (e.g. 2026-02-31) revert to the last valid display value. The calendar opens via the calendar button or ArrowDown; typed year/month/date (e.g. 2015) updates the calendar view immediately without requiring blur first. Range typing uses – / - separators. Focus-aware sync avoids overwriting in-progress typing; selection from the calendar wins over uncommitted text. Input uses cursor: text; the calendar icon keeps pointer. Includes Storybook note and unit tests for typing, revert, year navigation, and calendar selection.

## ✅ Checklist

* [x] Component added/updated in Storybook (if applicable)
* [x] Tests added/updated
* [x] UI matches approved design (Figma)
* [x] Accessibility reviewed (keyboard navigation, labels, semantics)
